### PR TITLE
use fft2K in fecfntrs

### DIFF
--- a/src/fecfntrs.h
+++ b/src/fecfntrs.h
@@ -11,7 +11,7 @@ template<typename T>
 class FECFNTRS : public FEC<T>
 {
  private:
-  FFTN<T> *fft = NULL;
+  FFT2K<T> *fft = NULL;
 
  public:
   T n;
@@ -30,11 +30,11 @@ class FECFNTRS : public FEC<T>
 
     // compute root of order n-1 such as r^(n-1) mod q == 1
     r = gf->get_nth_root(n);
-
+    
     // std::cerr << "n=" << n << "\n";
     // std::cerr << "r=" << r << "\n";
 
-    this->fft = new FFTN<T>(gf, n, r);
+    this->fft = new FFT2K<T>(gf, n);
   }
 
   ~FECFNTRS()

--- a/src/fftln.h
+++ b/src/fftln.h
@@ -40,8 +40,8 @@ FFTLN<T>::FFTLN(GF<T> *gf, int l, T w) : FFT<T>(gf, __gf64._exp2(l))
 
   this->W = new Vec<T>(gf, this->n + 1);
   this->inv_W = new Vec<T>(gf, this->n + 1);
-  gf->compute_omegas(W, this->n, w);
-  gf->compute_omegas(inv_W, this->n, inv_w);
+  gf->compute_omegas_cached(W, this->n, w);
+  gf->compute_omegas_cached(inv_W, this->n, inv_w);
 
   _pre_compute_consts();
 }

--- a/src/gf.h
+++ b/src/gf.h
@@ -64,6 +64,7 @@ class GF
   bool _solovay_strassen(T n);
   bool _is_prime(T n);
   void compute_omegas(Vec<T> *W, int n, T w);
+  void compute_omegas_cached(Vec<T> *W, int n, T w);
   T _weak_rand(T max);
   T weak_rand(void);
   void _factor_distinct_prime(T n, std::vector<T> *output);
@@ -574,6 +575,21 @@ bool GF<T>::_is_prime(T n)
 /**
  * Compute the different powers of the root of unity into a vector
  *
+ * @param W output vector (must be of length n+1)
+ * @param n
+ * @param w n-th root of unity
+ */
+template <typename T>
+void GF<T>::compute_omegas(Vec<T> *W, int n, T w)
+{
+  for (int i = 0; i <= n; i++) {
+    W->set(i, exp(w, i));
+  }
+}
+
+/**
+ * Compute the different powers of the root of unity into a vector
+ *
  * @note cache the result in a file called W<w>.cache
  *
  * @note XXX not reentrant
@@ -583,7 +599,7 @@ bool GF<T>::_is_prime(T n)
  * @param w n-th root of unity
  */
 template <typename T>
-void GF<T>::compute_omegas(Vec<T> *W, int n, T w)
+void GF<T>::compute_omegas_cached(Vec<T> *W, int n, T w)
 {
   std::ostringstream filename;
 

--- a/test/fft_utest.cpp
+++ b/test/fft_utest.cpp
@@ -242,7 +242,7 @@ class FFTUtest
     delete _Y;
   }
 
-  void test_fft()
+  void test_fftn()
   {
     u_int n;
     u_int r;
@@ -252,7 +252,7 @@ class FFTUtest
     u_int n_data = 3;
     u_int n_parities = 3;
 
-    std::cout << "test_fft\n";
+    std::cout << "test_fftn\n";
 
     assert(gf._jacobi(R, q) == -1);
 
@@ -282,7 +282,7 @@ class FFTUtest
     }
   }
 
-  void test_fft_bis()
+  void test_fft2k()
   {
     u_int n;
     u_int q = 65537;
@@ -291,7 +291,7 @@ class FFTUtest
     u_int n_data = 3;
     u_int n_parities = 3;
 
-    std::cout << "test_fft_bis\n";
+    std::cout << "test_fft2k\n";
 
     assert(gf._jacobi(R, q) == -1);
 
@@ -426,8 +426,8 @@ class FFTUtest
     test_chinese_remainder();
     test_quadratic_residues();
     test_jacobi();
-    test_fft();
-    test_fft_bis();
+    test_fftn();
+    test_fft2k();
     test_fft2();
     test_fft_gf2n();
     test_mul_bignum();

--- a/tools/test_ec.sh
+++ b/tools/test_ec.sh
@@ -5,6 +5,7 @@
 #valgrind=valgrind
 #valgrind="gdb --args"
 
+bin=./ec
 bs=50K
 #bs=1M
 
@@ -19,7 +20,7 @@ checkfail()
 
 do_test()
 {
-    bin=$1
+    directive=$1
     fec_type=$2
     word_size=$3
     n_data=$4
@@ -83,6 +84,12 @@ do_test()
         j=`expr ${j} + 1`
     done
 
+    if [ "${directive}" == "enconly" ]
+    then
+        echo
+        return
+    fi
+
     echo -n "REP,"
     ${valgrind} ${bin} -e ${fec_type} -w ${word_size} -n ${n_data} -m ${n_coding} -p foo -r ${extraopts} ${vflag}
     checkfail "repairing"
@@ -108,14 +115,15 @@ do
     fec_type=$(echo $i|cut -d_ -f1)
     word_size=$(echo $i|cut -d_ -f2)
 
-    do_test ./ec ${fec_type} ${word_size} 3 3 "" ""
-    do_test ./ec ${fec_type} ${word_size} 3 3 "0 1" "0"
-    do_test ./ec ${fec_type} ${word_size} 3 5 "0 1" "0"
-    do_test ./ec ${fec_type} ${word_size} 3 3 "1 2" "2"
-    do_test ./ec ${fec_type} ${word_size} 9 3 "1 2" "2"
-    do_test ./ec ${fec_type} ${word_size} 9 3 "2 3" "2"
-    do_test ./ec ${fec_type} ${word_size} 9 5 "2 3 4" "2 3"
-    do_test ./ec ${fec_type} ${word_size} 9 5 "1 3 5" "1 3"
-    do_test ./ec ${fec_type} ${word_size} 9 5 "1 3 5 7 8" ""
-    do_test ./ec ${fec_type} ${word_size} 9 5 "" "0 1 2 3 4"
+    do_test enconly ${fec_type} ${word_size} 50 50 "" ""
+    do_test all ${fec_type} ${word_size} 3 3 "" ""
+    do_test all ${fec_type} ${word_size} 3 3 "0 1" "0"
+    do_test all ${fec_type} ${word_size} 3 5 "0 1" "0"
+    do_test all ${fec_type} ${word_size} 3 3 "1 2" "2"
+    do_test all ${fec_type} ${word_size} 9 3 "1 2" "2"
+    do_test all ${fec_type} ${word_size} 9 3 "2 3" "2"
+    do_test all ${fec_type} ${word_size} 9 5 "2 3 4" "2 3"
+    do_test all ${fec_type} ${word_size} 9 5 "1 3 5" "1 3"
+    do_test all ${fec_type} ${word_size} 9 5 "1 3 5 7 8" ""
+    do_test all ${fec_type} ${word_size} 9 5 "" "0 1 2 3 4"
 done


### PR DESCRIPTION
don't cache omegas in fft2k (easy to compute for relatively small n)
keep omega caching for schonage-strassen
rename some badly named unit test
add large symbol (encode only) test for showing superiority of butterfly approach