### PR TITLE
FFTCT: Cooley-Tukey FFT algorithm

### DIFF
--- a/src/fecgf2nfftrs.h
+++ b/src/fecgf2nfftrs.h
@@ -8,7 +8,7 @@ template<typename T>
 class FECGF2NFFTRS : public FEC<T>
 {
  private:
-  FFTPF<T> *fft = NULL;
+  FFTCT<T> *fft = NULL;
   Poly<T> *prime_poly = NULL;
 
  public:
@@ -30,7 +30,7 @@ class FECGF2NFFTRS : public FEC<T>
     // std::cerr << "n=" << n << "\n";
     // std::cerr << "r=" << r << "\n";
 
-    this->fft = new FFTPF<T>(gf, n);
+    this->fft = new FFTCT<T>(gf, n);
   }
 
   ~FECGF2NFFTRS()

--- a/src/fftct.h
+++ b/src/fftct.h
@@ -102,7 +102,6 @@ template <typename T>
 void FFTCT<T>::_fft(Vec<T> *output, Vec<T> *input, bool inv)
 {
   Vec<T> G(this->gf, this->n);
-  G.zero_fill();
 
   for (T i1 = 0; i1 < n1; i1++) {
     VmVec<T> Gcol(&G, n2, i1, n1);
@@ -118,16 +117,20 @@ void FFTCT<T>::_fft(Vec<T> *output, Vec<T> *input, bool inv)
 
   // multiply to twiddle factors
   T factor;
-  T loc;
+  T _w;
+  if (inv)
+    _w = inv_w;
+  else
+    _w = w;
+  T base = 1;
   for (T i1 = 1; i1 < n1; i1++) {
+    base = this->gf->mul(base, _w); // base = _w^i1
+    factor = base; // init factor = base^1
     for (T k2 = 1; k2 < n2; k2++) {
-        loc = i1+n1*k2;
-      if (inv)
-        factor = this->gf->exp(inv_w, i1*k2);
-      else
-        factor = this->gf->exp(w, i1*k2);
-
+      T loc = i1+n1*k2;;
       G.set(loc, this->gf->mul(G.get(loc), factor));
+      // next factor = base^(k2+1)
+      factor = this->gf->mul(factor, base);
     }
   }
 

--- a/src/fftct.h
+++ b/src/fftct.h
@@ -1,0 +1,172 @@
+
+/* -*- mode: c++ -*- */
+
+#pragma once
+
+/**
+ * Cooley-Tukey FFT algorithm
+ *  Implementation based on S.K. Matra's slides
+ *    http://sip.cua.edu/res/docs/courses/ee515/chapter08/ch8-2.pdf
+ *
+ * Suppose n = n1*n2
+ *  X[k] = sum_i x_i * w_n^ik is plit into two smaller DFTs
+ * by using the index mapping
+ *  i = i1 + n1*i2
+ *  k = n2*k1 + k2
+ *  where 1 <= i1, k1 <= n1-1, 1 <= i2, k2 <= n2-1
+ *
+ *  X[n2*k1 + k2] =
+ *    sum_i1 [
+ *      (
+ *        sum_i2 x[i1 + n1*i2] * w_2^(i2*k2)
+ *      ) * w^(i1*k2)
+ *    ] w_1^(i1*k1)
+ *
+ *  where
+ *    w is nth root, w_1 = w^n2, w_2 = w^n1
+ *
+ *  Step1: calculate DFT of the inner parenthese, i.e. sum_i2...
+ *  Step2: multiply to twiddle factors w^(i1*k2)
+ *  Step3: calculate DFT of the outer parenthese, i.e. sum_i1
+ *
+ * @param output
+ * @param input
+ */
+template<typename T>
+class FFTCT : public FFT<T>
+{
+ private:
+  bool loop;
+  T N;
+  T n1;
+  T n2;
+  T w, w1, w2, inv_w;
+  std::vector<T>* prime_factors;
+  FFTN<T> *dft;
+  FFTCT<T> *fftct = NULL;
+ public:
+  FFTCT(GF<T> *gf, T n, int id = 0, std::vector<T>* prime_factors = NULL,
+    T _w = 0);
+  ~FFTCT();
+  void fft(Vec<T> *output, Vec<T> *input);
+  void ifft(Vec<T> *output, Vec<T> *input);
+ private:
+  void _fft(Vec<T> *output, Vec<T> *input, bool inv);
+};
+
+/**
+ * n-th root will be constructed with primitive root
+ *
+ * @param gf
+ * @param n
+ * @param id: index in the list of factors of n
+ *
+ * @return
+ */
+template <typename T>
+FFTCT<T>::FFTCT(GF<T> *gf, T n, int id, std::vector<T>* prime_factors, T _w) :
+  FFT<T>(gf, n)
+{
+  if (id == 0) {
+    this->N = n;
+    prime_factors = gf->_get_prime_factors(n);
+    // w is of order-n
+    w = gf->get_nth_root(n);
+  } else {
+    this->prime_factors = prime_factors;
+    w = _w;
+  }
+  inv_w = gf->inv(w);
+  n1 = prime_factors->at(id);
+  n2 = n/n1;
+
+  w1 = gf->exp(w, n2);  // order of w1 = n1
+  this->dft = new FFTN<T>(gf, n1, w1);
+
+  if (n2 > 1) {
+    loop = true;
+    w2 = gf->exp(w, n1);  // order of w2 = n2
+    this->fftct = new FFTCT<T>(gf, n/n1, id+1, prime_factors, w2);
+  } else
+    loop = false;
+}
+
+template <typename T>
+FFTCT<T>::~FFTCT()
+{
+  delete dft;
+  if (fftct) delete fftct;
+}
+
+template <typename T>
+void FFTCT<T>::_fft(Vec<T> *output, Vec<T> *input, bool inv)
+{
+  Vec<T> G(this->gf, this->n);
+  G.zero_fill();
+
+  for (T i1 = 0; i1 < n1; i1++) {
+    VmVec<T> Gcol(&G, n2, i1, n1);
+    VmVec<T> x(input, n2, i1, n1);
+    if (inv)
+      this->fftct->ifft(&Gcol, &x);
+    else
+      this->fftct->fft(&Gcol, &x);
+    // std::cout << "x:"; x.dump();
+    // std::cout << "Gcol:"; Gcol.dump();
+    // std::cout << "G:"; G.dump();
+  }
+
+  // multiply to twiddle factors
+  T factor;
+  T loc;
+  for (T i1 = 1; i1 < n1; i1++) {
+    for (T k2 = 1; k2 < n2; k2++) {
+        loc = i1+n1*k2;
+      if (inv)
+        factor = this->gf->exp(inv_w, i1*k2);
+      else
+        factor = this->gf->exp(w, i1*k2);
+
+      G.set(loc, this->gf->mul(G.get(loc), factor));
+    }
+  }
+
+  for (T k2 = 0; k2 < n2; k2++) {
+    VmVec<T> Grow(&G, n1, k2*n1, 1);
+    VmVec<T> X(output, n1, k2, n2);
+    if (inv)
+      this->dft->fft_inv(&X, &Grow);
+    else
+      this->dft->fft(&X, &Grow);
+    // std::cout << "Grow:"; Grow.dump();
+    // std::cout << "X:"; X.dump();
+    // std::cout << "output:"; output->dump();
+  }
+}
+
+template <typename T>
+void FFTCT<T>::fft(Vec<T> *output, Vec<T> *input)
+{
+  if (!loop)
+    return dft->fft(output, input);
+  else
+    return _fft(output, input, false);
+}
+
+template <typename T>
+void FFTCT<T>::ifft(Vec<T> *output, Vec<T> *input)
+{
+  if (!loop)
+    dft->fft_inv(output, input);
+  else
+    _fft(output, input, true);
+
+  /*
+   * We need to divide output to `N` for the inverse formular
+   */
+  if (this->N == this->n) {
+    T coef = this->gf->inv(this->N) % this->gf->p;
+    if (coef > 0)
+      output->mul_scalar(coef);
+  }
+}

--- a/src/fftpf.h
+++ b/src/fftpf.h
@@ -122,7 +122,6 @@ template <typename T>
 void FFTPF<T>::_fft(Vec<T> *output, Vec<T> *input, bool inv)
 {
   Vec<T> G(this->gf, this->n);
-  G.zero_fill();
 
   for (T i1 = 0; i1 < n1; i1++) {
     T offset = (a*i1) % this->n;

--- a/src/gf.h
+++ b/src/gf.h
@@ -83,6 +83,7 @@ class GF
   void _compute_all_divisors_h();
   T _get_code_len(T n);
   std::vector<T>* _get_coprime_factors(T nb);
+  std::vector<T>* _get_prime_factors(T nb);
   inline mpz_class _to_mpz_class(T nb) {
     std::stringstream _nb;
     _nb << nb;
@@ -92,6 +93,7 @@ class GF
  private:
   std::vector<T>* _all_divisors_h = NULL;
   std::vector<T>* _prime_factors = NULL;
+  std::vector<T>* _all_prime_factors = NULL;
 };
 
 template <typename T>
@@ -107,6 +109,7 @@ GF<T>::~GF()
 {
   delete this->_all_divisors_h;
   delete this->_prime_factors;
+  delete this->_all_prime_factors;
 }
 
 template <typename T>
@@ -1067,4 +1070,29 @@ std::vector<T> * GF<T>::_get_coprime_factors(T nb)
   }
 
   return _prime_factors;
+}
+
+/**
+ * get all prime factors of a number
+ *
+ * @param nb - a number to be refactored
+ * @return
+ */
+template <typename T>
+std::vector<T> * GF<T>::_get_prime_factors(T nb)
+{
+  if (nb == this->card_minus_one() && _all_prime_factors)
+    return _all_prime_factors;
+  std::vector<T> *_all_prime_factors = new std::vector<T>();
+
+  std::vector<T> primes;
+  std::vector<T> exponent;
+  _factor_prime(nb, &primes, &exponent);
+
+  typename std::vector<T>::size_type i, j;
+  for (i = 0; i != primes.size(); ++i)
+    for (j = 0; j != exponent.at(i); ++j) {
+      _all_prime_factors->push_back(primes[i]);
+    }
+  return _all_prime_factors;
 }

--- a/src/ntl.h
+++ b/src/ntl.h
@@ -55,6 +55,7 @@ typedef enum
 #include "fftn.h"
 #include "fftln.h"
 #include "fft2k.h"
+#include "fftct.h"
 #include "fftpf.h"
 #include "poly.h"
 #include "fec.h"

--- a/src/v2vec.h
+++ b/src/v2vec.h
@@ -26,7 +26,7 @@ class V2Vec : public Vec<T>
 };
 
 template <typename T>
-V2Vec<T>::V2Vec(Vec<T> *vec) : Vec<T>(NULL, 0)
+V2Vec<T>::V2Vec(Vec<T> *vec) : Vec<T>(vec->gf, vec->n)
 {
   this->vec = vec;
 }
@@ -47,4 +47,3 @@ T V2Vec<T>::get(int i)
   else
     return vec->get(i - vec->n);
 }
-

--- a/src/vmvec.h
+++ b/src/vmvec.h
@@ -23,7 +23,7 @@ class VmVec : public Vec<T>
 };
 
 template <typename T>
-VmVec<T>::VmVec(Vec<T> *vec, int n, int offset, int step) : Vec<T>(NULL, n)
+VmVec<T>::VmVec(Vec<T> *vec, int n, int offset, int step) : Vec<T>(vec->gf, n)
 {
   this->vec = vec;
   this->offset = offset;

--- a/src/vmvec.h
+++ b/src/vmvec.h
@@ -14,12 +14,13 @@ class VmVec : public Vec<T>
   int step;
   int N;
  public:
-  explicit VmVec(Vec<T> *vec, int n, int offset, int step);
+  explicit VmVec(Vec<T> *vec, int n = 0, int offset = 0, int step = 1);
   int get_n(void);
   T get(int i);
   void set(int i, T val);
-  Vec<T>* toVec();
-  void import(Vec<T>* v);
+  void set_map(int offset, int step);
+  void set_len(int n);
+  void set_vec(Vec<T> *vec);
 };
 
 template <typename T>
@@ -46,6 +47,29 @@ T VmVec<T>::get(int i)
 
   T loc = (offset + step * i) % this->N;
   return vec->get(loc);
+}
+
+template <typename T>
+void VmVec<T>::set_map(int offset, int step)
+{
+  this->offset = offset;
+  this->step = step;
+}
+
+template <typename T>
+void VmVec<T>::set_len(int n)
+{
+  assert(this->n <= this->N);
+  this->n = n;
+}
+
+template <typename T>
+void VmVec<T>::set_vec(Vec<T> *vec)
+{
+  assert(this->n <= vec->n);
+  this->vec = vec;
+  this->gf = vec->gf;
+  this->N = vec->n;
 }
 
 template <typename T>

--- a/src/vvec.h
+++ b/src/vvec.h
@@ -17,7 +17,7 @@ class VVec : public Vec<T>
 };
 
 template <typename T>
-VVec<T>::VVec(Vec<T> *vec, int n) : Vec<T>(NULL, n)
+VVec<T>::VVec(Vec<T> *vec, int n) : Vec<T>(vec->gf, n)
 {
   this->vec = vec;
   this->n = n;

--- a/test/fft_utest.cpp
+++ b/test/fft_utest.cpp
@@ -335,7 +335,72 @@ class FFTUtest
 
     FFTPF<T> fft = FFTPF<T>(&gf, n);
 
-    for (int j = 0; j < 1000; j++) {
+    for (int j = 0; j < 10000; j++) {
+      Vec<T> v(&gf, fft.n), _v(&gf, fft.n), v2(&gf, fft.n);
+      v.zero_fill();
+      for (int i = 0; i < n_data; i++)
+        v.set(i, gf.weak_rand());
+        // v.dump();
+      fft.fft(&_v, &v);
+        // _v.dump();
+      fft.ifft(&v2, &_v);
+      //   v2.dump();
+      assert(v.eq(&v2));
+    }
+  }
+
+  void test_fftct_gfp()
+  {
+    T n;
+    T q = 65537;
+    GFP<T> gf = GFP<T>(q);
+    T R = gf._get_prime_root();  // primitive root
+    T n_data = 3;
+    T n_parities = 3;
+
+    std::cout << "test_fftct_gfp\n";
+
+    // with this encoder we cannot exactly satisfy users request, we need to pad
+    // n = minimal divisor of (q-1) that is at least (n_parities + n_data)
+    n = gf._get_code_len(n_parities + n_data);
+
+    // std::cerr << "n=" << n << "\n";
+
+    FFTCT<T> fft = FFTCT<T>(&gf, n);
+
+    for (int j = 0; j < 10000; j++) {
+      Vec<T> v(&gf, fft.n), _v(&gf, fft.n), v2(&gf, fft.n);
+      v.zero_fill();
+      for (int i = 0; i < n_data; i++)
+        v.set(i, gf.weak_rand());
+        // v.dump();
+      fft.fft(&_v, &v);
+        // _v.dump();
+      fft.ifft(&v2, &_v);
+        // v2.dump();
+      assert(v.eq(&v2));
+    }
+  }
+
+  void test_fftct_gf2n()
+  {
+    T n;
+    GF2N<T> gf = GF2N<T>(4);
+    T R = gf._get_prime_root();  // primitive root
+    T n_data = 3;
+    T n_parities = 3;
+
+    std::cout << "test_fftct_gf2n\n";
+
+    // with this encoder we cannot exactly satisfy users request, we need to pad
+    // n = minimal divisor of (q-1) that is at least (n_parities + n_data)
+    n = gf._get_code_len(n_parities + n_data);
+
+    // std::cerr << "n=" << n << "\n";
+
+    FFTCT<T> fft = FFTCT<T>(&gf, n);
+
+    for (int j = 0; j < 10000; j++) {
       Vec<T> v(&gf, fft.n), _v(&gf, fft.n), v2(&gf, fft.n);
       v.zero_fill();
       for (int i = 0; i < n_data; i++)
@@ -493,6 +558,8 @@ class FFTUtest
     test_fftn();
     test_fft2k();
     test_fftpf();
+    test_fftct_gfp();
+    test_fftct_gf2n();
     test_fft2();
     test_fft2_gfp();
     test_fft_gf2n();


### PR DESCRIPTION
Implementation based on S.K. Matra's slides
   http://sip.cua.edu/res/docs/courses/ee515/chapter08/ch8-2.pdf

Suppose `n = n1*n2`
 `X[k] = sum_i x_i w_n^(i*k)` is split into two smaller DFTs
by using the index mapping
```
 i = i1 + n1*i2
 k = n2*k1 + k2
```
 where `1 <= i1, k1 <= n1-1, 1 <= i2, k2 <= n2-1`

```
 X[n2*k1 + k2] =
   sum_i1 [
     (
       sum_i2 x[i1 + n1*i2] w_2^(i2*k2)
     ) * w^(i1*k2)
   ] * w_1^(i1*k1)
```

 where
   `w` is nth root, `w_1 = w^n2, w_2 = w^n1`

 Step1: calculate DFT of the inner parenthese, i.e. `sum_i2(..)`.
 Step2: multiply to twiddle factors `w^(i1*k2)`
 Step3: calculate DFT of the outer parenthese, i.e. `sum_i1[...]`
