### PR TITLE
Allow FEC creating GF instance by itself

### DIFF
--- a/src/fec.h
+++ b/src/fec.h
@@ -29,7 +29,8 @@ class FEC
   GF<T> *gf;
 
  public:
-  FEC(GF<T> *gf, FECType type, u_int word_size, u_int n_data, u_int n_parities);
+  FEC(FECType type, u_int word_size, u_int n_data, u_int n_parities);
+
   /**
    * Return the number actual parities for TYPE_1 it is exactly n_parities, for
    * TYPE_2 it maybe at least n_data+n_parities (but sometimes more).
@@ -70,18 +71,15 @@ class FEC
 /**
  * Create an encoder
  *
- * @param gf
  * @param word_size in bytes
  * @param n_data
  * @param n_parities
  */
 template <typename T>
-FEC<T>::FEC(GF<T> *gf, FECType type, u_int word_size, u_int n_data,
-  u_int n_parities)
+FEC<T>::FEC(FECType type, u_int word_size, u_int n_data, u_int n_parities)
 {
   assert(type == TYPE_1 || type == TYPE_2);
 
-  this->gf = gf;
   this->type = type;
   this->word_size = word_size;
   this->n_data = n_data;

--- a/src/fecgf2nrs.h
+++ b/src/fecgf2nrs.h
@@ -21,14 +21,19 @@ class FECGF2NRS : public FEC<T>
   Mat<T> *decode_mat = NULL;
 
  public:
-  FECGF2NRS(GF<T> *gf, u_int word_size, u_int n_data, u_int n_parities,
+  FECGF2NRS(u_int word_size, u_int n_data, u_int n_parities,
     FECGF2NRSType type) :
-    FEC<T>(gf, FEC<T>::TYPE_1, word_size, n_data, n_parities)
+    FEC<T>(FEC<T>::TYPE_1, word_size, n_data, n_parities)
   {
     assert(type == VANDERMONDE || type == CAUCHY);
     this->type = type;
 
-    this->mat = new Mat<T>(gf, n_parities, n_data);
+    if (word_size > 16)
+      assert(false); // not support yet
+    u_int gf_n = 8*word_size;
+    this->gf = new GF2N<T>(gf_n);
+
+    this->mat = new Mat<T>(this->gf, n_parities, n_data);
     if (type == CAUCHY) {
       mat->cauchy();
     } else if (type == VANDERMONDE) {
@@ -43,11 +48,16 @@ class FECGF2NRS : public FEC<T>
   {
     delete mat;
     delete decode_mat;
+    delete this->gf;
   }
 
   int get_n_outputs()
   {
     return this->n_parities;
+  }
+
+  GF<T>* get_gf() {
+    return this->gf;
   }
 
   void encode(Vec<T> *output, std::vector<KeyValue*> props, off_t offset,

--- a/src/gf.h
+++ b/src/gf.h
@@ -991,6 +991,7 @@ T GF<T>::_get_prime_root()
     this->find_prime_root();
   return this->root;
 }
+
 /**
  * compute all divisors of q-1
  *
@@ -1030,18 +1031,24 @@ void GF<T>::_compute_all_divisors_h()
 template <typename T>
 T GF<T>::_get_code_len(T n)
 {
-  T q_minus_one = card_minus_one();
-  if (q_minus_one % n == 0) return n;
-  if (q_minus_one < n) assert(false);
+  T nb = card_minus_one();
+  if (nb % n == 0) return n;
+  if (nb < n) assert(false);
 
-  if (!_all_divisors_h) {
-    _compute_all_divisors_h();
+  T _sqrt = sqrt(nb);
+  T i;
+  if (n > _sqrt) {
+    T max = nb/n;
+    for (i = 1; i <= max; i++) {
+      // if i divides n, return n/i
+      if (nb % i == 0)
+        return nb/i;
+    }
   }
-
-  typename std::vector<T>::size_type i;
-  for (i = 0; i != _all_divisors_h->size(); i++) {
-    if (n <= _all_divisors_h->at(i))
-      return _all_divisors_h->at(i);
+  for (i = n; i <= _sqrt; i++) {
+    // if i divides n, return i
+    if (nb % i == 0)
+      return i;
   }
   return 0;
 }

--- a/src/gf.h
+++ b/src/gf.h
@@ -27,9 +27,8 @@ class GF
   T n;
   T root;
 
- protected:
   GF(T p, T n);
-  ~GF();
+  virtual ~GF();
 
  public:
   virtual T card(void) = 0;

--- a/test/fec_utest.cpp
+++ b/test/fec_utest.cpp
@@ -10,17 +10,17 @@ class FECUtest
     u_int n_data = 3;
     u_int n_parities = 3;
 
-    GFP<T> gf = GFP<T>(65537);
-    FECFNTRS<T> fec = FECFNTRS<T>(&gf, 2, n_data, n_parities);
+    FECFNTRS<T> fec = FECFNTRS<T>(2, n_data, n_parities);
+    GF<T> *gf = fec.get_gf();
 
+    Vec<T> v(gf, n_data), _v(gf, fec.n), _v2(gf, n_data), f(gf, n_data),
+      v2(gf, n_data);
     for (int j = 0; j < 10000; j++) {
-      Vec<T> v(&gf, n_data), _v(&gf, fec.n), _v2(&gf, n_data), f(&gf, n_data),
-        v2(&gf, n_data);
       std::vector<KeyValue*>props(fec.n, nullptr);
       for (int i = 0; i < fec.n; i++)
         props[i] = new KeyValue();
       for (int i = 0; i < n_data; i++)
-        v.set(i, gf.weak_rand());
+        v.set(i, gf->weak_rand());
       // v.dump();
       fec.encode(&_v, props, 0, &v);
       // _v.dump();
@@ -36,25 +36,26 @@ class FECUtest
   }
 
   void test_fecgf2nfftrs() {
-    for (int n = 4; n < 128 && n <= 8 * sizeof(T); n *= 2)
-      test_fecgf2nfftrs_with_n(n);
+    std::cout << "test_fecgf2nfftrs with sizeof(T)=" << sizeof(T) << "\n";
+    for (int wordsize = 1; wordsize <= sizeof(T); wordsize *= 2)
+      test_fecgf2nfftrs_with_wordsize(wordsize);
   }
-  void test_fecgf2nfftrs_with_n(int n)
+  void test_fecgf2nfftrs_with_wordsize(int wordsize)
   {
-    std::cout << "test_fecgf2nfftrs_with_n=" << n << "\n";
+    std::cout << "test_fecgf2nfftrs_with_wordsize=" << wordsize << "\n";
 
     u_int n_data = 3;
     u_int n_parities = 3;
 
-    GF2N<T> gf = GF2N<T>(n);
-    FECGF2NFFTRS<T> fec = FECGF2NFFTRS<T>(&gf, 2, n_data, n_parities);
+    FECGF2NFFTRS<T> fec = FECGF2NFFTRS<T>(wordsize, n_data, n_parities);
+    GF<T> *gf = fec.get_gf();
 
     std::vector<KeyValue*> props;
+    Vec<T> v(gf, n_data), _v(gf, fec.n), _v2(gf, n_data), f(gf, n_data),
+      v2(gf, n_data);
     for (int j = 0; j < 10000; j++) {
-      Vec<T> v(&gf, n_data), _v(&gf, fec.n), _v2(&gf, n_data), f(&gf, n_data),
-        v2(&gf, n_data);
       for (int i = 0; i < n_data; i++)
-        v.set(i, gf.weak_rand());
+        v.set(i, gf->weak_rand());
       // v.dump();
       fec.encode(&_v, props, 0, &v);
       // _v.dump();

--- a/tools/ec.cpp
+++ b/tools/ec.cpp
@@ -229,9 +229,7 @@ void run_FECGF2NRS(int word_size, int n_data, int n_parities, gf2nrs_type mflag,
     gf2nrs_type = FECGF2NRS<T>::VANDERMONDE;
   else
     gf2nrs_type = FECGF2NRS<T>::CAUCHY;
-  GF2N<T> *gf = new GF2N<T>(word_size * 8);
-  fec = new FECGF2NRS<T>(gf, word_size, n_data, n_parities,
-    gf2nrs_type);
+  fec = new FECGF2NRS<T>(word_size, n_data, n_parities, gf2nrs_type);
 
   if (tflag) {
     print_fec_type<T>(fec);
@@ -245,15 +243,13 @@ void run_FECGF2NRS(int word_size, int n_data, int n_parities, gf2nrs_type mflag,
   create_coding_files<T>(fec);
   print_stats<T>(fec);
   delete fec;
-  delete gf;
 }
 
 template <typename T>
 void run_FECGF2NFFTRS(int word_size, int n_data, int n_parities, int rflag)
 {
   FECGF2NFFTRS<T> *fec;
-  GF2N<T> *gf = new GF2N<T>(word_size * 8);
-  fec = new FECGF2NFFTRS<T>(gf, word_size, n_data, n_parities);
+  fec = new FECGF2NFFTRS<T>(word_size, n_data, n_parities);
 
   if (tflag) {
     print_fec_type<T>(fec);
@@ -267,16 +263,13 @@ void run_FECGF2NFFTRS(int word_size, int n_data, int n_parities, int rflag)
   create_coding_files<T>(fec);
   print_stats<T>(fec);
   delete fec;
-  delete gf;
 }
 
 template <typename T>
 void run_FECFNTRS(int word_size, int n_data, int n_parities, int rflag)
 {
   FECFNTRS<T> *fec;
-  //warning all fermat numbers greater or equal to F_5 (2^32+1) are composite!!!
-  GFP<T> *gf = new GFP<T>(__gf32._exp(2, word_size * 8)+1); 
-  fec = new FECFNTRS<T>(gf, word_size, n_data, n_parities);
+  fec = new FECFNTRS<T>(word_size, n_data, n_parities);
 
   if (tflag) {
     print_fec_type<T>(fec);
@@ -290,7 +283,6 @@ void run_FECFNTRS(int word_size, int n_data, int n_parities, int rflag)
   create_coding_files<T>(fec);
   print_stats<T>(fec);
   delete fec;
-  delete gf;
 }
 
 enum ec_type


### PR DESCRIPTION
Two parameters (gf_p, gf_n) given as parameters of FEC are used to
create GF instance:

- FECFNT: creates GFP(gf_p, 1)
- FECGF2NFFT, FECGF2N: creates GF2N(2, gf_n)

GF instance can be exported to external use by using get_gf() function