### PR TITLE
FECGFPFFTRS: GFP(p) based RS

### DIFF
--- a/src/gf.h
+++ b/src/gf.h
@@ -1038,8 +1038,7 @@ T GF<T>::_get_code_len(T n)
   T _sqrt = sqrt(nb);
   T i;
   if (n > _sqrt) {
-    T max = nb/n;
-    for (i = 1; i <= max; i++) {
+    for (i = nb/n; i >= 1; i--) {
       // if i divides n, return n/i
       if (nb % i == 0)
         return nb/i;

--- a/src/ntl.h
+++ b/src/ntl.h
@@ -62,3 +62,4 @@ typedef enum
 #include "fecgf2nrs.h"
 #include "fecfntrs.h"
 #include "fecgf2nfftrs.h"
+#include "fecgfpfftrs.h"

--- a/test/fec_utest.cpp
+++ b/test/fec_utest.cpp
@@ -15,8 +15,8 @@ class FECUtest
 
     Vec<T> v(gf, n_data), _v(gf, fec.n), _v2(gf, n_data), f(gf, n_data),
       v2(gf, n_data);
+    std::vector<KeyValue*>props(fec.n, nullptr);
     for (int j = 0; j < 10000; j++) {
-      std::vector<KeyValue*>props(fec.n, nullptr);
       for (int i = 0; i < fec.n; i++)
         props[i] = new KeyValue();
       for (int i = 0; i < n_data; i++)
@@ -68,12 +68,48 @@ class FECUtest
      }
   }
 
+  void test_fecgfpfftrs() {
+    std::cout << "test_fecgfpfftrs with sizeof(T)=" << sizeof(T) << "\n";
+    for (int word_size = 1; word_size <= 4 && word_size < sizeof(T); word_size *= 2)
+      test_fecgfpfftrs_with_word_size(word_size);
+  }
+  void test_fecgfpfftrs_with_word_size(int word_size)
+  {
+    std::cout << "test_fecgfpfftrs_with_word_size=" << word_size << "\n";
+
+    u_int n_data = 3;
+    u_int n_parities = 3;
+
+    FECGFPFFTRS<T> fec = FECGFPFFTRS<T>(word_size, n_data, n_parities);
+    GF<T> *gf = fec.get_gf();
+
+    Vec<T> v(gf, n_data), _v(gf, fec.n), _v2(gf, n_data), f(gf, n_data),
+      v2(gf, n_data);
+    std::vector<KeyValue*>props(fec.n, nullptr);
+    for (int j = 0; j < 10000; j++) {
+      for (int i = 0; i < fec.n; i++)
+        props[i] = new KeyValue();
+      for (int i = 0; i < n_data; i++)
+        v.set(i, gf->weak_rand());
+      // v.dump();
+      fec.encode(&_v, props, 0, &v);
+      // _v.dump();
+      _v2.copy(&_v, n_data);
+      for (int i = 0; i < n_data; i++)
+        f.set(i, i);
+      fec.decode(&v2, props, 0, &f, &_v2);
+      // v2.dump();
+      assert(v.eq(&v2));
+     }
+  }
+
   void fec_utest()
   {
     std::cout << "fec_utest\n";
 
     test_fecfntrs();
     test_fecgf2nfftrs();
+    test_fecgfpfftrs();
   }
 };
 
@@ -83,6 +119,7 @@ template class FEC<uint32_t>;
 template class FECGF2NRS<uint32_t>;
 template class FECFNTRS<uint32_t>;
 template class FECGF2NFFTRS<uint32_t>;
+template class FECGFPFFTRS<uint32_t>;
 
 template class Mat<uint64_t>;
 template class Vec<uint64_t>;
@@ -90,6 +127,15 @@ template class FEC<uint64_t>;
 template class FECGF2NRS<uint64_t>;
 template class FECFNTRS<uint64_t>;
 template class FECGF2NFFTRS<uint64_t>;
+template class FECGFPFFTRS<uint64_t>;
+
+template class Mat<__uint128_t>;
+template class Vec<__uint128_t>;
+template class FEC<__uint128_t>;
+template class FECGF2NRS<__uint128_t>;
+// template class FECFNTRS<uint64_t>;
+template class FECGF2NFFTRS<__uint128_t>;
+template class FECGFPFFTRS<__uint128_t>;
 
 template class Mat<mpz_class>;
 template class Vec<mpz_class>;

--- a/tools/test_ec.sh
+++ b/tools/test_ec.sh
@@ -110,7 +110,7 @@ do_test()
     echo
 }
 
-for i in fntrs_1 fntrs_2 gf2nfftrs_1 gf2nfftrs_2 gf2nfftrs_4 gf2nfftrs_8 gf2nrsv_1 gf2nrsv_2 gf2nrsc_1 gf2nrsc_2 gf2nrsv_4 gf2nrsv_8 gf2nrsv_16 gf2nrsc_4 gf2nrsc_8 gf2nrsc_16
+for i in fntrs_1 fntrs_2 gfpfftrs_1 gfpfftrs_2 gfpfftrs_4 gf2nfftrs_1 gf2nfftrs_2 gf2nfftrs_4 gf2nfftrs_8 gf2nrsv_1 gf2nrsv_2 gf2nrsc_1 gf2nrsc_2 gf2nrsv_4 gf2nrsv_8 gf2nrsv_16 gf2nrsc_4 gf2nrsc_8 gf2nrsc_16
 do
     fec_type=$(echo $i|cut -d_ -f1)
     word_size=$(echo $i|cut -d_ -f2)


### PR DESCRIPTION
Necessary condition: `p >= 2^(8*word_size)` to cover all possible values of symbols, as each symbol is of `(8*word_size)` bits.

A length-`k` vector `X` is encoded into a length-`n` vector `Y` whose elements are GFP elements. Hence, elements of `Y` could be greater than `2^(8*word_size)`.

Note: to facilitate our implementation, we CHOOSE `p < 2 * 2^(8*word_size)`.
We can deal with this as below.
Supposing that an element `Y[i] > 2^(8*word_size)`, we will store its value modulo `2^(8*word_size)`, i.e.

```
Y_p[i] = Y[i] % 2^(8*word_size),
```

a flag will be marked for the position `i`.

To decode `X`, we read `Y[i]` from `Y_p[i]` as:

```
Y[i] = Y_p[i] + 2^(8*word_size)
```
Because `p < 2 * 2^(8*word_size)`, the flag will be only a bool value.
