### PR TITLE
get code len high compo

### DIFF
--- a/src/fecfntrs.h
+++ b/src/fecfntrs.h
@@ -30,7 +30,7 @@ class FECFNTRS : public FEC<T>
 
     // with this encoder we cannot exactly satisfy users request, we need to pad
     // n = minimal divisor of (q-1) that is at least (n_parities + n_data)
-    n = this->gf->_get_code_len(n_parities + n_data);
+    n = this->gf->_get_code_len_high_compo(n_parities + n_data);
 
     // compute root of order n-1 such as r^(n-1) mod q == 1
     r = this->gf->get_nth_root(n);

--- a/src/fecgf2nfftrs.h
+++ b/src/fecgf2nfftrs.h
@@ -25,7 +25,7 @@ class FECGF2NFFTRS : public FEC<T>
 
     // with this encoder we cannot exactly satisfy users request, we need to pad
     // n = minimal divisor of (q-1) that is at least (n_parities + n_data)
-    n = this->gf->_get_code_len(n_parities + n_data);
+    n = this->gf->_get_code_len_high_compo(n_parities + n_data);
 
     // compute root of order n such as r^n == 1
     this->r = this->gf->get_nth_root(n);

--- a/src/fecgfpfftrs.h
+++ b/src/fecgfpfftrs.h
@@ -55,7 +55,7 @@ class FECGFPFFTRS : public FEC<T>
 
     // with this encoder we cannot exactly satisfy users request, we need to pad
     // n = minimal divisor of (q-1) that is at least (n_parities + n_data)
-    n = this->gf->_get_code_len(n_parities + n_data);
+    n = this->gf->_get_code_len_high_compo(n_parities + n_data);
 
     // compute root of order n-1 such as r^(n-1) mod q == 1
     r = this->gf->get_nth_root(n);

--- a/src/gf.h
+++ b/src/gf.h
@@ -81,6 +81,7 @@ class GF
   T get_nth_root(T n);
   void _compute_all_divisors_h();
   T _get_code_len(T n);
+  T _get_code_len_high_compo(T n);
   std::vector<T>* _get_coprime_factors(T nb);
   std::vector<T>* _get_prime_factors(T nb);
   inline mpz_class _to_mpz_class(T nb) {
@@ -1048,6 +1049,40 @@ T GF<T>::_get_code_len(T n)
     // if i divides n, return i
     if (nb % i == 0)
       return i;
+  }
+  return 0;
+}
+
+/**
+ * find smallest number is
+ *  - highly composited
+ *  - at least n
+ *  - divisible by (q-1)
+ *
+ * @param n
+ *
+ * @return root
+ */
+template <typename T>
+T GF<T>::_get_code_len_high_compo(T n)
+{
+  T nb = card_minus_one();
+  if (nb < n) assert(false);
+
+  std::vector<T> *factors = this->_get_prime_factors(nb);
+  T x = 1;
+  typename std::vector<T>::size_type i, j;
+  // forward to get a divisor of (q-1) >= n and of highly composited
+  for (i = 0; i != factors->size(); ++i) {
+    x *= factors->at(i);
+    if (x >= n) {
+      // backward to get smaller number
+      for (int j = 0; j != i; j++) {
+        x /= factors->at(j);
+        if (x < n)
+          return x * factors->at(j);
+      }
+    }
   }
   return 0;
 }


### PR DESCRIPTION
Given n_data, n_parity and q-1, a code length is chosen being a number:

- divisible by (q-1)
- max number of composites
- at least n

Example:
(q-1) = 2^6 * 3^2 * 31
n_data + n_parity = 25
Then, choose n = 2^5 = 32 instead 31