### PR TITLE
FFT2K is preferably used

### DIFF
--- a/src/fecgfpfftrs.h
+++ b/src/fecgfpfftrs.h
@@ -23,7 +23,7 @@ template<typename T>
 class FECGFPFFTRS : public FEC<T>
 {
  private:
-  FFTCT<T> *fft = NULL;
+  FFT<T> *fft = NULL;
   T limit_value;
 
  public:
@@ -65,7 +65,10 @@ class FECGFPFFTRS : public FEC<T>
     // std::cerr << "n=" << n << "\n";
     // std::cerr << "r=" << r << "\n";
 
-    this->fft = new FFTCT<T>(this->gf, n);
+    if (this->gf->_is_power_of_2(n))
+      this->fft = new FFT2K<T>(this->gf, n);
+    else
+      this->fft = new FFTCT<T>(this->gf, n);
   }
 
   ~FECGFPFFTRS()

--- a/src/fft.h
+++ b/src/fft.h
@@ -16,8 +16,10 @@ class FFT
  protected:
   FFT(GF<T> *gf, int n);
  public:
+  virtual ~FFT() {};
   virtual void fft(Vec<T> *output, Vec<T> *input) = 0;
   virtual void ifft(Vec<T> *output, Vec<T> *input) = 0;
+  virtual void fft_inv(Vec<T> *output, Vec<T> *input) = 0;
 };
 
 template <typename T>

--- a/src/fft2k.h
+++ b/src/fft2k.h
@@ -35,6 +35,7 @@ class FFT2K : public FFT<T>
   ~FFT2K();
   void fft(Vec<T> *output, Vec<T> *input);
   void ifft(Vec<T> *output, Vec<T> *input);
+  void fft_inv(Vec<T> *output, Vec<T> *input);
  private:
   void _fft(Vec<T> *output, Vec<T> *input, bool inv);
 };
@@ -118,11 +119,6 @@ void FFT2K<T>::_fft(Vec<T> *output, Vec<T> *input, bool inv)
     output->copy(W, this->n);
   output->hadamard_mul(&vodd);
   output->add(&veven);
-  /*
-   * We need to divide output to `N` for the inverse formular
-   */
-  if (inv && this->k == this->N / 2)
-    output->mul_scalar(this->gf->inv(this->N) % this->gf->p);
 }
 
 template <typename T>
@@ -137,10 +133,22 @@ void FFT2K<T>::fft(Vec<T> *output, Vec<T> *input)
 }
 
 template <typename T>
-void FFT2K<T>::ifft(Vec<T> *output, Vec<T> *input)
+void FFT2K<T>::fft_inv(Vec<T> *output, Vec<T> *input)
 {
   if (bypass)
     return fft2->fft_inv(output, input);
   else
     return _fft(output, input, true);
+}
+
+template <typename T>
+void FFT2K<T>::ifft(Vec<T> *output, Vec<T> *input)
+{
+  fft_inv(output, input);
+
+  /*
+   * We need to divide output to `N` for the inverse formular
+   */
+  if ((this->k == this->N / 2) && (this->inv_n_mod_p > 1))
+      output->mul_scalar(this->inv_n_mod_p);
 }

--- a/src/fftln.h
+++ b/src/fftln.h
@@ -29,6 +29,7 @@ class FFTLN : public FFT<T>
   ~FFTLN();
   void fft(Vec<T> *output, Vec<T> *input);
   void ifft(Vec<T> *output, Vec<T> *input);
+  void fft_inv(Vec<T> *output, Vec<T> *input);
 };
 
 template <typename T>
@@ -200,8 +201,15 @@ void FFTLN<T>::fft(Vec<T> *output, Vec<T> *input)
 }
 
 template <typename T>
-void FFTLN<T>::ifft(Vec<T> *output, Vec<T> *input)
+void FFTLN<T>::fft_inv(Vec<T> *output, Vec<T> *input)
 {
   _fft(output, input, inv_W);
-  output->mul_scalar(this->inv_n_mod_p);
+}
+
+template <typename T>
+void FFTLN<T>::ifft(Vec<T> *output, Vec<T> *input)
+{
+  fft_inv(output, input);
+  if (this->inv_n_mod_p > 1)
+    output->mul_scalar(this->inv_n_mod_p);
 }


### PR DESCRIPTION
FFT2K and FFT2 are preferably used, particularly for fftct and fftpf.

Define fft_inv in all fft, that perform inverse fft without multiplying
to the coefficient N^(-1)