### PR TITLE
Additive FFT: enhancement

### DIFF
--- a/src/fecgfpfftrs.h
+++ b/src/fecgfpfftrs.h
@@ -35,14 +35,15 @@ class FECGFPFFTRS : public FEC<T>
   {
     // warning all fermat numbers >= to F_5 (2^32+1) are composite!!!
     T gf_p;
-    if (word_size < 4)
+    if (word_size < 4) {
        gf_p = (1ULL << (8*word_size)) + 1;
-    else if (word_size == 4)
+       this->limit_value = (1ULL << (8 * word_size));
+    } else if (word_size == 4) {
       gf_p = 4294991873;  // p-1=2^13 29^1 101^1 179^1
-    else
+      this->limit_value = 4294967296;   // 2^32
+    } else
       assert(false);  // not support yet
 
-    this->limit_value = (1ULL << (8 * word_size));
 
     assert(gf_p >= this->limit_value);
     // we choose gf_p for a simple implementation

--- a/src/fftct.h
+++ b/src/fftct.h
@@ -96,10 +96,11 @@ FFTCT<T>::FFTCT(GF<T> *gf, T n, int id, std::vector<T>* factors, T _w) :
     loop = true;
     w2 = gf->exp(w, n1);  // order of w2 = n2
     T _n2 = n/n1;
-    if (_is_power_of_2<T>(_n2))
-      this->dft_inner = new FFTCT<T>(gf, _n2);
-    else
-      this->dft_inner = new FFTCT<T>(gf, _n2, id+1, this->prime_factors, w2);
+    // TODO: fix that FFT2K does not work here
+    // if (_is_power_of_2<T>(_n2))
+    //   this->dft_inner = new FFT2K<T>(gf, _n2);
+    // else
+    this->dft_inner = new FFTCT<T>(gf, _n2, id+1, this->prime_factors, w2);
     this->G = new Vec<T>(this->gf, this->n);
     this->Y = new VcVec<T>(this->G);
     this->X = new VcVec<T>(this->G);

--- a/src/rn.h
+++ b/src/rn.h
@@ -64,6 +64,11 @@ RN<T>::RN(T card)
 {
   this->_card = card;
   this->root = 0;
+
+  this->primes = new std::vector<T>();
+  this->exponent = new std::vector<T>();
+  this->all_primes_factors = new std::vector<T>();
+  this->proper_divisors = new std::vector<T>();
 }
 
 template <typename T>
@@ -275,11 +280,6 @@ void RN<T>::compute_factors_of_order()
   if (this->compute_factors_of_order_done) return;
 
   T h = this->card_minus_one();
-  this->primes = new std::vector<T>();
-  this->exponent = new std::vector<T>();
-  this->all_primes_factors = new std::vector<T>();
-  this->proper_divisors = new std::vector<T>();
-
   // prime factorisation of order, i.e. order = p_i^e_i where
   //  p_i, e_i are ith element of this->primes and this->exponent
   _factor_prime<T>(h, this->primes, this->exponent);

--- a/src/v2vec.h
+++ b/src/v2vec.h
@@ -23,7 +23,6 @@ class V2Vec : public Vec<T>
   explicit V2Vec(Vec<T> *vec);
   int get_n(void);
   T get(int i);
-  T *get_mem();
   bool is_v2vec();
 };
 
@@ -57,10 +56,4 @@ T V2Vec<T>::get(int i)
     return vec->get(i);
   else
     return vec->get(i - vec_n);
-}
-
-template <typename T>
-T *V2Vec<T>::get_mem()
-{
-  return vec->get_mem();
 }

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -61,51 +61,55 @@ void _vec_add_65537(int n,
 }
 
 template <>
-void Vec<uint32_t>::hadamard_mul(Vec<uint32_t> *v)
+void Vec<uint32_t>::hadamard_mul(V2Vec<uint32_t> *v)
 {
   assert(n == v->get_n());
 
-  if (!is_v2vec() && v->is_v2vec()) {
-    //typical butterfly operation
-    if (rn->card() == 257) {
-      uint32_t *a = get_mem();
-      uint32_t *b = v->get_mem();
-      _vec_hadamard_mul_257(n, a, b);
-      return ;
-    } else if (rn->card() == 65537) {
-      uint32_t *a = get_mem();
-      uint32_t *b = v->get_mem();
-      _vec_hadamard_mul_65537(n, a, b);
-      return ;
-    }
+  //typical butterfly operation
+  if (rn->card() == 257) {
+    uint32_t *a = get_mem();
+    uint32_t *b = v->get_mem();
+    _vec_hadamard_mul_257(n, a, b);
+    return ;
+  } else if (rn->card() == 65537) {
+    uint32_t *a = get_mem();
+    uint32_t *b = v->get_mem();
+    _vec_hadamard_mul_65537(n, a, b);
+    return ;
   }
-  
-  for (int i = 0; i < n; i++)
-    set(i, rn->mul(get(i), v->get(i)));
+  uint32_t *src = v->get_mem();
+  int i;
+  int j;
+  for (i = 0; i < n / 2; i++)
+    mem[i] = rn->mul(mem[i], src[i]);
+  for (j = 0; i < n; i++, j++)
+    mem[i] = rn->mul(mem[i], src[j]);
 }
 
 template <>
-void Vec<uint32_t>::add(Vec<uint32_t> *v)
+void Vec<uint32_t>::add(V2Vec<uint32_t> *v)
 {
   assert(n == v->get_n());
 
-  if (!is_v2vec() && v->is_v2vec()) {
-    //typical butterfly operation
-    if (rn->card() == 257) {
-      uint32_t *a = get_mem();
-      uint32_t *b = v->get_mem();
-      _vec_add_257(n, a, b);
-      return ;
-    } else if (rn->card() == 65537) {
-      uint32_t *a = get_mem();
-      uint32_t *b = v->get_mem();
-      _vec_add_65537(n, a, b);
-      return ;
-    }
+  //typical butterfly operation
+  if (rn->card() == 257) {
+    uint32_t *a = get_mem();
+    uint32_t *b = v->get_mem();
+    _vec_add_257(n, a, b);
+    return ;
+  } else if (rn->card() == 65537) {
+    uint32_t *a = get_mem();
+    uint32_t *b = v->get_mem();
+    _vec_add_65537(n, a, b);
+    return ;
   }
-
-  for (int i = 0; i < n; i++)
-    set(i, rn->add(get(i), v->get(i)));
+  uint32_t *src = v->get_mem();
+  int i;
+  int j;
+  for (i = 0; i < n / 2; i++)
+    mem[i] = rn->add(mem[i], src[i]);
+  for (j = 0; i < n; i++, j++)
+    mem[i] = rn->add(mem[i], src[j]);
 }
 
 void _vec_hadamard_mul_257(int n,
@@ -169,49 +173,53 @@ void _vec_add_65537(int n,
 }
 
 template <>
-void Vec<uint64_t>::hadamard_mul(Vec<uint64_t> *v)
+void Vec<uint64_t>::hadamard_mul(V2Vec<uint64_t> *v)
 {
   assert(n == v->get_n());
 
-  if (!is_v2vec() && v->is_v2vec()) {
-    //typical butterfly operation
-    if (rn->card() == 257) {
-      uint64_t *a = get_mem();
-      uint64_t *b = v->get_mem();
-      _vec_hadamard_mul_257(n, a, b);
-      return ;
-    } else if (rn->card() == 65537) {
-      uint64_t *a = get_mem();
-      uint64_t *b = v->get_mem();
-      _vec_hadamard_mul_65537(n, a, b);
-      return ;
-    }
+  //typical butterfly operation
+  if (rn->card() == 257) {
+    uint64_t *a = get_mem();
+    uint64_t *b = v->get_mem();
+    _vec_hadamard_mul_257(n, a, b);
+    return ;
+  } else if (rn->card() == 65537) {
+    uint64_t *a = get_mem();
+    uint64_t *b = v->get_mem();
+    _vec_hadamard_mul_65537(n, a, b);
+    return ;
   }
-  
-  for (int i = 0; i < n; i++)
-    set(i, rn->mul(get(i), v->get(i)));
+  uint64_t *src = v->get_mem();
+  int i;
+  int j;
+  for (i = 0; i < n / 2; i++)
+    mem[i] = rn->mul(mem[i], src[i]);
+  for (j = 0; i < n; i++, j++)
+    mem[i] = rn->mul(mem[i], src[j]);
 }
 
 template <>
-void Vec<uint64_t>::add(Vec<uint64_t> *v)
+void Vec<uint64_t>::add(V2Vec<uint64_t> *v)
 {
   assert(n == v->get_n());
 
-  if (!is_v2vec() && v->is_v2vec()) {
-    //typical butterfly operation
-    if (rn->card() == 257) {
-      uint64_t *a = get_mem();
-      uint64_t *b = v->get_mem();
-      _vec_add_257(n, a, b);
-      return ;
-    } else if (rn->card() == 65537) {
-      uint64_t *a = get_mem();
-      uint64_t *b = v->get_mem();
-      _vec_add_65537(n, a, b);
-      return ;
-    }
+  //typical butterfly operation
+  if (rn->card() == 257) {
+    uint64_t *a = get_mem();
+    uint64_t *b = v->get_mem();
+    _vec_add_257(n, a, b);
+    return ;
+  } else if (rn->card() == 65537) {
+    uint64_t *a = get_mem();
+    uint64_t *b = v->get_mem();
+    _vec_add_65537(n, a, b);
+    return ;
   }
-
-  for (int i = 0; i < n; i++)
-    set(i, rn->add(get(i), v->get(i)));
+  uint64_t *src = v->get_mem();
+  int i;
+  int j;
+  for (i = 0; i < n / 2; i++)
+    mem[i] = rn->add(mem[i], src[i]);
+  for (j = 0; i < n; i++, j++)
+    mem[i] = rn->add(mem[i], src[j]);
 }

--- a/test/fec_utest.cpp
+++ b/test/fec_utest.cpp
@@ -149,10 +149,7 @@ template class GFP<mpz_class>;
 void fec_utest()
 {
   FECUtest<uint32_t> fec_utest_uint32;
-  //fecgfpfftrs overflows
-  fec_utest_uint32.test_fecfntrs();
-  fec_utest_uint32.test_fecgf2nfftrs();
-  fec_utest_uint32.test_fecgf2nfftaddrs();
+  fec_utest_uint32.fec_utest();
   FECUtest<uint64_t> fec_utest_uint64;
   fec_utest_uint64.fec_utest();
   FECUtest<__uint128_t> fec_utest_uint128;

--- a/test/vec_utest.cpp
+++ b/test/vec_utest.cpp
@@ -95,12 +95,38 @@ class VECUtest
     assert(vec1.get(7) == 58879);
   }
 
+  void vec_utest3()
+  {
+    std::cout << "vec_utest3\n";
+
+    GFP<T> gfp(65537);
+    int len = 20;
+    Vec<T> base_vec(&gfp, len);
+    for (int i = 0; i < len; i++)
+      base_vec.set(i, gfp.weak_rand());
+    int len1 = 7;
+    int len2 = 5;
+    int offset1 = 2;
+    int offset2 = 3;
+    int len3 = len2;
+    if (offset2 + len2 > len1)
+      len3 = len1 - offset2;
+    // vmvec1 = base_vec[offset1, .., offset1 + len1 - 1]
+    VmVec<T> vmvec1(&base_vec, len1, offset1);
+    // vmvec2 = vmvec1[offset2, .., min(offset2 + len2 - 1, len1 - 1)]
+    VmVec<T> vmvec2(&vmvec1, len2, offset2);
+    // vmvec3 = base_vec[offset1 + offset2, .., offset1 + len1 - 1]
+    VmVec<T> vmvec3(&base_vec, len3, offset1 + offset2);
+    assert(vmvec3.eq(&vmvec2));
+  }
+
   void vec_utest()
   {
     std::cout << "vec_utest\n";
 
     vec_utest1();
     vec_utest2();
+    vec_utest3();
   }
 };
 


### PR DESCRIPTION
# FFTADD: enhancement

- Use hadamard_mul to multiply beta_m_powers
- Taylor expansion performs directly at input vector. At the end of this step, input vector will be list of polynomials h_i(x). Hence,  g0 and g1 are calculated as even and odd indexed sub-array of input.

# Vec: enhancement

- add, add_mutual, hadamard_mul: perform operations directly at array mem instead of use member functions
- make functions be inline: get, set, get_mem
- disvirtualize get_mem
- add set_mem function
- add hadamard_mul specifically for V2Vec vector

# VmVec: simplification and enhancement

- There is no longer step in VmVec
- Introduce mem_offset as its mem array
- Remove get_mem

