### PR TITLE
Minor enhancement & clean codes

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -1,7 +1,7 @@
 
 #CXX = clang++
 
-CXXFLAGS = -std=c++11  -I../benchmark -I../src -g -O2 -DNDEBUG
+CXXFLAGS = -std=c++11  -I../src -g -O2 -Werror -Wall #-DNDEBUG
 LDFLAGS = -L../src -lntl -lgmpxx -lgmp
 
 OBJS = benchmark.o

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -221,7 +221,7 @@ int Benchmark<T>::init() {
     c_chunks_id->push_back(i);
   }
 
-  this->enc_stats = new Stats_t("Encode", chunk_size*k);
+  this->enc_stats = new Stats_t("Encode", chunk_size*n_c);
   this->dec_stats = new Stats_t("Decode", chunk_size*k);
   return 1;
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@
 
 AR = ar cq
 
-CXXFLAGS = -std=c++11 -g -O2 #-DNDEBUG
+CXXFLAGS = -std=c++11 -g -O2 -Werror -Wall #-DNDEBUG
 
 OBJS = misc.o config.o vec.o
 

--- a/src/arith.h
+++ b/src/arith.h
@@ -413,7 +413,6 @@ bool _solovay_strassen1(T a, T n)
 template <class T>
 bool _solovay_strassen(T n)
 {
-  int ok = 0;
   for (int i = 0; i < 100; i++) {
     T a = _weak_rand<T>(n);
     if (!solovay_strassen1(a, n))
@@ -472,7 +471,6 @@ template <class T>
 T _weak_rand0(T max)
 {
   T r;
- retry:
   r = rand() % max;
   return r;
 }

--- a/src/big_int.h
+++ b/src/big_int.h
@@ -42,7 +42,7 @@ struct int256_t
   }
   bool operator<(int x)
   {
-    return (lo < x);
+    return (lo < (__uint128_t)x);
   }
   bool operator!=(__uint128_t x)
   {
@@ -50,7 +50,7 @@ struct int256_t
   }
   bool operator!=(int x)
   {
-    return (lo != x);
+    return (lo != (__uint128_t)x);
   }
   int256_t operator+(__uint128_t x)
   {

--- a/src/fec.h
+++ b/src/fec.h
@@ -3,14 +3,14 @@
 
 #include <sys/time.h>
 
-static timeval tick()
+static inline timeval tick()
 {
   struct timeval tv;
   gettimeofday(&tv, nullptr);
   return tv;
 }
 
-static uint64_t hrtime_usec(timeval begin)
+static inline uint64_t hrtime_usec(timeval begin)
 {
   struct timeval tv;
   gettimeofday(&tv, nullptr);
@@ -316,11 +316,9 @@ bool FEC<T>::decode_bufs(std::vector<std::istream*> input_data_bufs,
 
   decode_build();
 
-  int n_words;
+  int n_words = code_len;
   if (type == TYPE_1)
     n_words = n_data;
-  else if (type == TYPE_2)
-    n_words = code_len;
 
   Vec<T> words(gf, n_words);
   Vec<T> fragments_ids(gf, n_words);

--- a/src/fec.h
+++ b/src/fec.h
@@ -131,7 +131,7 @@ FEC<T>::~FEC()
 }
 
 template <typename T>
-bool FEC<T>::readw(T *ptr, std::istream *stream)
+inline bool FEC<T>::readw(T *ptr, std::istream *stream)
 {
   if (word_size == 1) {
     u_char c;
@@ -170,7 +170,7 @@ bool FEC<T>::readw(T *ptr, std::istream *stream)
 }
 
 template <typename T>
-bool FEC<T>::writew(T val, std::ostream *stream)
+inline bool FEC<T>::writew(T val, std::ostream *stream)
 {
   if (word_size == 1) {
     u_char c = val;

--- a/src/fecfntrs.h
+++ b/src/fecfntrs.h
@@ -24,9 +24,7 @@ class FECFNTRS : public FEC<T>
     T gf_p = (1ULL << (8*word_size)) + 1;
     this->gf = new GFP<T>(gf_p);
 
-    T q = this->gf->card();
-    T R = this->gf->get_prime_root();  // primitive root
-    assert(_jacobi<T>(R, q) == -1);
+    assert(_jacobi<T>(this->gf->get_prime_root(), this->gf->card()) == -1);
 
     // with this encoder we cannot exactly satisfy users request, we need to pad
     // n = minimal divisor of (q-1) that is at least (n_parities + n_data)

--- a/src/fecgfpfftrs.h
+++ b/src/fecgfpfftrs.h
@@ -34,15 +34,17 @@ class FECGFPFFTRS : public FEC<T>
     FEC<T>(FEC<T>::TYPE_2, word_size, n_data, n_parities)
   {
     // warning all fermat numbers >= to F_5 (2^32+1) are composite!!!
-    T gf_p;
+    T gf_p = 0;
     if (word_size < 4) {
        gf_p = (1ULL << (8*word_size)) + 1;
        this->limit_value = (1ULL << (8 * word_size));
     } else if (word_size == 4) {
-      gf_p = 4294991873;  // p-1=2^13 29^1 101^1 179^1
-      this->limit_value = 4294967296;   // 2^32
-    } else
+      gf_p = (T)4294991873ULL;  // p-1=2^13 29^1 101^1 179^1
+      this->limit_value = (T)4294967296ULL;   // 2^32
+    } else {
       assert(false);  // not support yet
+      exit(1);
+    }
 
 
     assert(gf_p >= this->limit_value);
@@ -50,9 +52,7 @@ class FECGFPFFTRS : public FEC<T>
     assert(gf_p / 2 < this->limit_value);
 
     this->gf = new GFP<T>(gf_p);
-    T q = this->gf->card();
-    T R = this->gf->get_prime_root();  // primitive root
-    assert(_jacobi<T>(R, q) == -1);
+    assert(_jacobi<T>(this->gf->get_prime_root(), this->gf->card()) == -1);
 
     // with this encoder we cannot exactly satisfy users request, we need to pad
     // n = minimal divisor of (q-1) that is at least (n_parities + n_data)

--- a/src/fftadd.h
+++ b/src/fftadd.h
@@ -214,7 +214,6 @@ void FFTADD<T>::compute_subspace(Vec<T> *basis, Vec<T> *subspace)
 template <typename T>
 void FFTADD<T>::_fft(Vec<T> *output, Vec<T> *input)
 {
-  int i;
   mem->copy(input, this->n);
   if (beta_m > 1)
     mem->hadamard_mul(beta_m_powers);
@@ -241,7 +240,6 @@ void FFTADD<T>::_fft(Vec<T> *output, Vec<T> *input)
 template <typename T>
 void FFTADD<T>::_ifft(Vec<T> *output, Vec<T> *input)
 {
-  int i;
   output->zero_fill();
   /*
    * input = (w0, w1)

--- a/src/gf2n.h
+++ b/src/gf2n.h
@@ -205,10 +205,7 @@ template <typename T>
 void GF2N<T>::setup_split_tables(void)
 {
   T i, j, t;
-  T nb = 0x100;   // 1 << 8
-  T d = 0x10000;  // 1 << 16
   T x;
-  T tab_card = tab_nb * d;
   T base;
 
   // alloc

--- a/src/mat.h
+++ b/src/mat.h
@@ -12,7 +12,7 @@ class Mat
 {
  public:
   Mat(RN<T> *rn, int n_rows, int n_cols);
-  ~Mat();
+  virtual ~Mat();
   virtual int get_n_rows();
   virtual int get_n_cols();
   void zero_fill(void);

--- a/src/rn.h
+++ b/src/rn.h
@@ -235,7 +235,6 @@ template <typename T>
 T RN<T>::exp_quick(T base, T exponent)
 {
   T result;
-  T i;
 
   if (0 == exponent)
     return 1;

--- a/src/vec.h
+++ b/src/vec.h
@@ -19,7 +19,7 @@ class Vec
  public:
   RN<T> *rn;
   Vec(RN<T> *rn, int n, T* mem=NULL, int mem_len=0);
-  ~Vec();
+  virtual ~Vec();
   virtual int get_n(void);
   int get_mem_len(void);
   void zero_fill(void);
@@ -252,8 +252,7 @@ template <typename T>
 void Vec<T>::add_mutual(Vec<T> *v, int offset, int len)
 {
   assert(len == 0 || n - offset >= len);
-  int _len = v->get_n();
-  assert(_len >= len);
+  assert(v->get_n() >= len);
   T *src = v->get_mem();
   T *dest = this->mem + offset;
   for (int i = 0; i < len; i++)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,7 @@
 
 #CXX = clang++
 
-CXXFLAGS = -std=c++11 -I../src -g
+CXXFLAGS = -std=c++11 -I../src -g -Werror -Wall
 LDFLAGS = -L../src -lntl -lgmpxx -lgmp
 
 OBJS = arith_utest.o gf_utest.o rs_utest.o vec_utest.o mat_utest.o fft_utest.o poly_utest.o fec_utest.o main.o

--- a/test/arith_utest.cpp
+++ b/test/arith_utest.cpp
@@ -112,10 +112,10 @@ class ArithUtest
 
     int b = 10;  // base
     int p = 14;  // we could multiply integers of 2^p digits
-    T max_digits = _exp<T>(2, p);
+    // T max_digits = _exp<T>(2, p);
     // std::cerr << "p=" << p << " max_digits=" << max_digits << "\n";
 
-    T l = p + 1;
+    // T l = p + 1;
     // std::cerr << "l=" << l << "\n";
 
     // choose 2 prime numbers of the form p=a.2^n+1

--- a/test/fft_utest.cpp
+++ b/test/fft_utest.cpp
@@ -89,7 +89,7 @@ class FFTUtest
 
     int b = 10;  // base
     int p = 14;  // we could multiply integers of 2^p digits
-    int max_digits = _exp<T>(2, p);
+    // int max_digits = _exp<T>(2, p);
     // std::cerr << "p=" << p << " max_digits=" << max_digits << "\n";
 
     uint64_t l = p + 1;
@@ -268,7 +268,6 @@ class FFTUtest
   {
     T n;
     GF2N<T> gf = GF2N<T>(4);
-    T R = gf.get_prime_root();  // primitive root
     T n_data = 3;
     T n_parities = 3;
 
@@ -301,7 +300,6 @@ class FFTUtest
     T n;
     T q = 65537;
     GFP<T> gf = GFP<T>(q);
-    T R = gf.get_prime_root();  // primitive root
     T n_data = 3;
     T n_parities = 3;
 
@@ -336,7 +334,6 @@ class FFTUtest
     T n_parities = 3;
     for (int gf_n = 4; gf_n <= 128 && gf_n <= 8 * sizeof(T); gf_n *= 2) {
       GF2N<T> gf = GF2N<T>(gf_n);
-      T R = gf.get_prime_root();  // primitive root
 
       std::cout << "test_fftct_gf2n=" << gf_n << "\n";
 
@@ -450,17 +447,14 @@ class FFTUtest
 
   void test_fft2_gfp()
   {
-    T n;
     GFP<T> gf = GFP<T>(3);
-    T R = gf.get_prime_root();  // primitive root
     T n_data = 1;
-    T n_parities = 1;
 
     std::cout << "test_fft2_gfp\n";
 
     // with this encoder we cannot exactly satisfy users request, we need to pad
     // n = minimal divisor of (q-1) that is at least (n_parities + n_data)
-    n = gf.get_code_len(n_parities + n_data);
+    // n = gf.get_code_len(n_parities + n_data);
 
     // std::cerr << "n=" << n << "\n";
 

--- a/test/gf_utest.cpp
+++ b/test/gf_utest.cpp
@@ -198,7 +198,6 @@ class GFUtest
     int i;
     T x;
     T nth_root;
-    T h = gf->card_minus_one();
     for (i = 0; i < 1000; i++) {
       // std::cout << "i=" << i << "\n";
       // std::cout << gf->card() << "\n";

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -27,9 +27,8 @@ struct test {
 
 int main(int argc, char **argv)
 {
-  bool run_all = true;
   struct test *p;
-    
+
   srand(0);
 
   if (2 == argc) {

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,7 +1,7 @@
 
 #CXX = clang++
 
-CXXFLAGS = -std=c++11 -I../src -g -O2 -DNDEBUG
+CXXFLAGS = -std=c++11 -I../src -g -O2 -Werror -Wall -DNDEBUG
 LDFLAGS = -L../src -lntl -lgmpxx -lgmp
 
 all: ec #find_pminus1_compo is_prime find_primes

--- a/tools/ec.cpp
+++ b/tools/ec.cpp
@@ -369,9 +369,9 @@ bool check(int n, int word_size, ec_type eflag)
   if (word_size >= 4)
     return true;
   if (eflag == EC_TYPE_FNTRS) {
-    return (n <= (1ULL << (8*word_size)) + 1);
+    return (n <= (1LL << (8*word_size)) + 1);
   } else {
-    return (n <= (1ULL << (8*word_size)));
+    return (n <= (1LL << (8*word_size)));
   }
 }
 
@@ -497,7 +497,6 @@ int main(int argc, char **argv)
       run_FECGF2NFFTADDRS<__uint128_t>(word_size, n_data, n_parities, rflag);
   }
 
- end:
   free(prefix);
   return 0;
 }

--- a/tools/ec.cpp
+++ b/tools/ec.cpp
@@ -59,9 +59,9 @@ void create_coding_files(FEC<T> *fec)
 {
   char filename[1024];
   std::vector<std::istream*> d_files(fec->n_data, nullptr);
-  std::vector<std::ostream*> c_files(fec->code_len, nullptr);
-  std::vector<std::ostream*> c_props_files(fec->code_len, nullptr);
-  std::vector<KeyValue*> c_props(fec->code_len, nullptr);
+  std::vector<std::ostream*> c_files(fec->n_outputs, nullptr);
+  std::vector<std::ostream*> c_props_files(fec->n_outputs, nullptr);
+  std::vector<KeyValue*> c_props(fec->n_outputs, nullptr);
 
   for (int i = 0; i < fec->n_data; i++) {
     snprintf(filename, sizeof (filename), "%s.d%d", prefix, i);
@@ -70,7 +70,7 @@ void create_coding_files(FEC<T> *fec)
     d_files[i] = new std::ifstream(filename);
   }
 
-  for (int i = 0; i < fec->code_len; i++) {
+  for (int i = 0; i < fec->n_outputs; i++) {
     snprintf(filename, sizeof (filename), "%s.c%d", prefix, i);
     if (vflag)
       std::cerr<< "create: opening coding for writing " << filename << "\n";
@@ -90,7 +90,7 @@ void create_coding_files(FEC<T> *fec)
     delete d_files[i];
   }
 
-  for (int i = 0; i < fec->code_len; i++) {
+  for (int i = 0; i < fec->n_outputs; i++) {
     *(c_props_files[i]) << *(c_props[i]);
 
     (static_cast<std::ofstream*>(c_props_files[i]))->close();
@@ -111,9 +111,9 @@ bool repair_data_files(FEC<T> *fec)
 {
   char filename[1024];
   std::vector<std::istream*> d_files(fec->n_data, nullptr);
-  std::vector<std::istream*> c_files(fec->code_len, nullptr);
-  std::vector<std::istream*> c_props_files(fec->code_len, nullptr);
-  std::vector<KeyValue*> c_props(fec->code_len, nullptr);
+  std::vector<std::istream*> c_files(fec->n_outputs, nullptr);
+  std::vector<std::istream*> c_props_files(fec->n_outputs, nullptr);
+  std::vector<KeyValue*> c_props(fec->n_outputs, nullptr);
   std::vector<std::ostream*> r_files(fec->n_data, nullptr);
 
   // re-read data
@@ -132,7 +132,7 @@ bool repair_data_files(FEC<T> *fec)
     }
   }
 
-  for (int i = 0; i < fec->code_len; i++) {
+  for (int i = 0; i < fec->n_outputs; i++) {
     snprintf(filename, sizeof (filename), "%s.c%d", prefix, i);
     if (vflag)
       std::cerr << "repair: checking coding " << filename << "\n";
@@ -166,7 +166,7 @@ bool repair_data_files(FEC<T> *fec)
     }
   }
 
-  for (int i = 0; i < fec->code_len; i++) {
+  for (int i = 0; i < fec->n_outputs; i++) {
     if (nullptr != c_props_files[i]) {
       (static_cast<std::ifstream*>(c_props_files[i]))->close();
       delete c_props_files[i];


### PR DESCRIPTION
# Enhancement

- FEC: use inline for read/write words

# Bench: modify encoding speed formula

Encoding speed is now defined as below

enc_speed = chunk_size * number_coded_chunks / encoding_time

For systematic codes, number_coded_chunks = number of parities
Otherwise, number_coded_chunks = code length

# Clean codes

Makefile with -Werror -Wall flags