### PR TITLE
Wrapper of packet

### DIFF
--- a/src/ntl.h
+++ b/src/ntl.h
@@ -57,6 +57,7 @@ typedef enum
 #include "vvec.h"
 #include "v2vec.h"
 #include "vecp.h"
+#include "vvecp.h"
 #include "vcvec.h"
 #include "vmvec.h"
 #include "mat.h"

--- a/src/ntl.h
+++ b/src/ntl.h
@@ -56,6 +56,7 @@ typedef enum
 #include "vec.h"
 #include "vvec.h"
 #include "v2vec.h"
+#include "vecp.h"
 #include "vcvec.h"
 #include "vmvec.h"
 #include "mat.h"

--- a/src/vecp.h
+++ b/src/vecp.h
@@ -1,0 +1,231 @@
+/* -*- mode: c++ -*- */
+#pragma once
+
+/*
+ * Wrapper of a vector of `n` buffers each of `size` elements of type T
+ *  std::vector<T*> vec(n)
+ *    vec[i] = T[size];
+ */
+
+template<typename T>
+class Vecp
+{
+ private:
+  bool new_mem = true;
+ protected:
+  std::vector<T*> *mem = nullptr;
+  int mem_len;
+  size_t size;
+  int n;
+ public:
+  Vecp(int n, size_t size, std::vector<T*> *mem=nullptr);
+  Vecp(Vecp<T>* vec, int n = 0);
+  virtual ~Vecp();
+  virtual int get_n(void);
+  virtual size_t get_size(void);
+  int get_mem_len(void);
+  void zero_fill(void);
+  virtual void set(int i, T* buf);
+  virtual T* get(int i);
+  std::vector<T*>* get_mem();
+  void set_mem(std::vector<T*> *mem);
+  void copy(Vecp<T> *v);
+  Vecp<T>* slice(int begin, int end);
+  void separate_even_odd();
+  void separate_even_odd(Vecp<T> *even, Vecp<T> *odd);
+  bool eq(Vecp<T> *v);
+  virtual void dump(void);
+};
+
+template<typename T>
+Vecp<T>::Vecp(int n, size_t size, std::vector<T*> *mem)
+{
+  this->n = n;
+  this->size = size;
+  this->mem_len = n*size;
+  if (mem == nullptr) {
+    this->mem = new std::vector<T*>(n, nullptr);
+    for (int i = 0; i < n; i++) {
+      this->mem->at(i) = new T[size];
+    }
+  } else {
+    new_mem = false;
+    this->mem = mem;
+  }
+}
+
+template<typename T>
+Vecp<T>::Vecp(Vecp<T>* vec, int n)
+{
+  assert(n >= 0);
+  int i;
+  int vec_n = vec->get_n();
+
+  this->size = vec->get_size();
+  this->n = (n == 0) ? vec_n : n;
+  this->mem = new std::vector<T*>(this->n, nullptr);
+
+  for (i = 0; i < this->n; i++) {
+    this->mem->at(i) = new T[this->size];
+  }
+
+  int copy_len = (this->n <= vec_n) ? this->n : vec_n;
+  for (i = 0; i < copy_len; i++) {
+    std::copy_n(vec->get(i), this->size, this->mem->at(i));
+  }
+
+  if (this->n > vec_n) {  // padding zeros
+    for (i = vec_n; i < this->n; i++) {
+      std::memset(this->mem->at(i), 0, this->size * sizeof(T));
+    }
+  }
+}
+
+template <typename T>
+Vecp<T>::~Vecp()
+{
+  if (new_mem && (this->mem != nullptr)) {
+    for (int i = 0; i < n; i++) {
+      delete[] this->mem->at(i);
+    }
+    delete this->mem;
+  }
+}
+
+template <typename T>
+inline int Vecp<T>::get_n(void)
+{
+  return n;
+}
+
+template <typename T>
+inline size_t Vecp<T>::get_size(void)
+{
+  return size;
+}
+
+template <typename T>
+inline int Vecp<T>::get_mem_len(void)
+{
+  return mem_len;
+}
+
+template <typename T>
+void Vecp<T>::zero_fill(void)
+{
+  for (int i = 0; i < n; i++)
+    std::memset(mem->at(i), 0, size*sizeof(T));
+}
+
+template <typename T>
+inline void Vecp<T>::set(int i, T* buf)
+{
+  assert(i >= 0 && i < n);
+
+  if (new_mem && this->mem->at(i) != nullptr)
+    delete[] this->mem->at(i);
+
+  this->mem->at(i) = buf;
+}
+
+template <typename T>
+inline T* Vecp<T>::get(int i)
+{
+  assert(i >= 0 && i < n);
+  return this->mem->at(i);
+}
+
+template <typename T>
+inline std::vector<T*> *Vecp<T>::get_mem()
+{
+  return mem;
+}
+
+template <typename T>
+inline void Vecp<T>::set_mem(std::vector<T*> *mem)
+{
+  this->mem = mem;
+}
+
+template <typename T>
+void Vecp<T>::copy(Vecp<T> *v)
+{
+  assert(v->get_n() == n);
+  assert(v->get_size() <= size);
+  size_t v_size = v->get_size();
+  for (int i = 0; i < n; i++)
+    std::copy_n(v->get(i), v_size, this->mem->at(i));
+}
+
+template <typename T>
+Vecp<T>* Vecp<T>::slice(int begin, int end)
+{
+  assert(begin >= 0 && begin < end);
+  assert(end <= n);
+  typename std::vector<T*>::const_iterator first = mem->begin() + begin;
+  typename std::vector<T*>::const_iterator last = mem->begin() + end;
+  std::vector<T*> *sliced_mem = new std::vector<T*>(first, last);
+  Vecp<T> *new_vec = new Vecp<T>(end - begin, size, sliced_mem);
+  return new_vec;
+}
+
+template <typename T>
+void Vecp<T>::separate_even_odd()
+{
+  std::vector<T*> _mem(n, nullptr);
+  int half = n / 2;
+  int j = 0;
+  int i;
+  for (i = 0; i < n; i += 2) {
+    _mem[j] = get(i);         // even
+    _mem[j+half] = get(i+1);  // odd
+    j++;
+  }
+  for (i = 0; i < n; i++) {
+    mem->at(i) = _mem[i];
+  }
+}
+
+template <typename T>
+void Vecp<T>::separate_even_odd(Vecp<T> *even, Vecp<T> *odd)
+{
+  int j = 0;
+  int i;
+  std::vector<T*> *even_mem = even->get_mem();
+  std::vector<T*> *odd_mem = odd->get_mem();
+  for (i = 0; i < n; i += 2) {
+    even_mem->at(j) = get(i);   // even
+    odd_mem->at(j) = get(i+1);  // odd
+    j++;
+  }
+}
+
+template <typename T>
+bool Vecp<T>::eq(Vecp<T> *v)
+{
+  if ((v->get_n() != n) || (v->get_size() != size))
+    return false;
+
+  for (int i = 0; i < n; i++) {
+    T *a = get(i);
+    T *b = v->get(i);
+    for (int j = 0; j < size; j++) {
+      if (a[j] != b[j])
+        return false;
+    }
+  }
+
+  return true;
+}
+
+template <typename T>
+void Vecp<T>::dump(void)
+{
+  for (int i = 0; i < n; i++) {
+    std::cout << "\n\t" << i << ": ";
+    for (int j = 0; j < size; j++) {
+      std::cout << unsigned((get(i))[j]) << "-";
+    }
+  }
+  std::cout << "\n)\n";
+}

--- a/src/vvecp.h
+++ b/src/vvecp.h
@@ -1,0 +1,43 @@
+/* -*- mode: c++ -*- */
+#pragma once
+
+/**
+ * Virtual vector that padds zero_chunk beyond managed vector length
+ */
+template<typename T>
+class VVecp : public Vecp<T>
+{
+ private:
+  Vecp<T> *vec;
+  int vec_n;
+  T *zero_chunk = nullptr;
+ public:
+  VVecp(Vecp<T> *vec, int n);
+  ~VVecp();
+};
+
+template <typename T>
+VVecp<T>::VVecp(Vecp<T> *vec, int n) :
+  Vecp<T>(n, vec->get_size(), vec->get_mem())
+{
+  this->vec = vec;
+  vec_n = vec->get_n();
+  assert(n >= vec_n);
+  // overwrite by a new vector
+  this->mem = new std::vector<T*>(vec->get_mem()->begin(),
+                                  vec->get_mem()->end());
+  if (n > vec_n) {
+    zero_chunk = new T[this->size];
+    std::memset(zero_chunk, 0, this->size * sizeof(T));
+    this->mem->resize(n, zero_chunk);
+  }
+}
+
+template <typename T>
+VVecp<T>::~VVecp()
+{
+  if (zero_chunk != nullptr) {
+    delete zero_chunk;
+  }
+  delete this->mem;
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,7 +4,7 @@
 CXXFLAGS = -std=c++11 -I../src -g -Werror -Wall
 LDFLAGS = -L../src -lntl -lgmpxx -lgmp
 
-OBJS = arith_utest.o gf_utest.o rs_utest.o vec_utest.o mat_utest.o fft_utest.o poly_utest.o fec_utest.o main.o
+OBJS = arith_utest.o gf_utest.o rs_utest.o vec_utest.o vecp_utest.o mat_utest.o fft_utest.o poly_utest.o fec_utest.o main.o
 
 all: tests
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -5,6 +5,7 @@ extern void arith_utest();
 extern void gf_utest();
 extern void rs_utest();
 extern void vec_utest();
+extern void vecp_utest();
 extern void mat_utest();
 extern void fft_utest();
 extern void poly_utest();
@@ -17,6 +18,7 @@ struct test {
   {"arith", arith_utest},
   {"gf", gf_utest},
   {"vec", vec_utest},
+  {"vecp", vec_utest},
   {"mat", mat_utest},
   {"rs", rs_utest},
   {"poly", poly_utest},

--- a/test/vecp_utest.cpp
+++ b/test/vecp_utest.cpp
@@ -1,0 +1,147 @@
+
+#include "ntl.h"
+
+template<typename T>
+class VECPUtest
+{
+ private:
+   GFP<T> *gfp;
+
+ public:
+  VECPUtest() {
+    this->gfp = new GFP<T>(65537);
+  }
+  ~VECPUtest() {
+    delete this->gfp;
+  }
+
+  Vecp<T>* gen_vecp_rand_data(int n, int size) {
+    Vecp<T> *vec = new Vecp<T>(n, size);
+    for (int i = 0; i < n; i++) {
+      T *buf = new T[size];
+      for (int j = 0; j < size; j++) {
+        buf[j] = this->gfp->weak_rand();
+      }
+      vec->set(i, buf);
+    }
+    // vec.dump();
+
+    return vec;
+  }
+
+  void vecp_utest1()
+  {
+    std::cout << "vecp_utest1\n";
+
+    int n = 16;
+    int begin = 5;
+    int end = 12;
+    int size = 32;
+    int i, j;
+
+    Vecp<T> *vec1 = gen_vecp_rand_data(n, size);
+    std::vector<T*> *mem1 = vec1->get_mem();
+    // vec1->dump();
+
+    Vecp<T> *vec2 = vec1->slice(begin, end);
+    std::vector<T*> *mem2 = vec2->get_mem();
+    assert(vec2->get_n() == end - begin);
+    assert(vec2->get_size() == vec1->get_size());
+    for (i = 0; i < end - begin; i++) {
+      for (j = 0; j < size; j++) {
+        mem2->at(i)[j] = mem1->at(i + begin)[j];
+      }
+    }
+    // vec2->dump();
+
+    std::vector<T*> mem3(end - begin, nullptr);
+    for (int i = 0; i < end - begin; i++) {
+      mem3[i] = mem1->at(i + begin);
+    }
+    Vecp<T> vec3(end - begin, size, &mem3);
+    // vec3.dump();
+
+    assert(vec2->eq(&vec3));
+
+    delete vec1;
+    delete vec2;
+  }
+
+  void vecp_utest2()
+  {
+    std::cout << "vecp_utest2\n";
+
+    int n = 8;
+    int size = 32;
+    int i, j;
+    int half = n / 2;
+
+    Vecp<T> *vec1 = gen_vecp_rand_data(n, size);
+    Vecp<T> vec2(n, size);
+    vec2.copy(vec1);
+
+    std::vector<T*> *even_mem = new std::vector<T*>(half, nullptr);
+    std::vector<T*> *odd_mem = new std::vector<T*>(half, nullptr);
+    Vecp<T> *i_even = new Vecp<T>(half, size, even_mem);
+    Vecp<T> *i_odd = new Vecp<T>(half, size, odd_mem);
+    vec1->separate_even_odd(i_even, i_odd);
+
+    // vec1->dump();
+    vec1->separate_even_odd();
+    // vec1->dump();
+
+    assert(i_even->eq(vec1->slice(0, half)));
+    assert(i_odd->eq(vec1->slice(half, n)));
+
+    // vec2.dump();
+
+    std::vector<T*> *mem1 = vec1->get_mem();
+    std::vector<T*> *mem2 = vec2.get_mem();
+
+    bool ok = true;
+    for (i = 0; i < n/2; i += 2) {
+      T *even1 = mem1->at(i);
+      T *even2 = mem2->at(i*2);
+      T *odd1 = mem1->at(i+n/2);
+      T *odd2 = mem2->at(i*2+1);
+      for (j = 0; j < size; j++) {
+        if(even1[j] != even2[j] ||
+           odd1[j] != odd2[j]) {
+          ok = false;
+          i = n;
+          break;
+        }
+      }
+    }
+    assert(ok);
+
+
+    delete vec1;
+  }
+
+  void vecp_utest()
+  {
+    std::cout << "vecp_utest with sizeof(T)=" << sizeof(T) << "\n";
+
+    vecp_utest1();
+    vecp_utest2();
+  }
+};
+
+template class GF<uint32_t>;
+template class GFP<uint32_t>;
+template class GF2N<uint32_t>;
+template class Vec<uint32_t>;
+
+template class GF<uint64_t>;
+template class GFP<uint64_t>;
+template class GF2N<uint64_t>;
+template class Vec<uint64_t>;
+
+void vecp_utest()
+{
+  VECPUtest<uint32_t> vecputest_uint32;
+  vecputest_uint32.vecp_utest();
+  VECPUtest<uint64_t> vecputest_uint64;
+  vecputest_uint64.vecp_utest();
+}

--- a/test/vecp_utest.cpp
+++ b/test/vecp_utest.cpp
@@ -115,8 +115,35 @@ class VECPUtest
     }
     assert(ok);
 
-
     delete vec1;
+  }
+
+  void vecp_utest3()
+  {
+    std::cout << "vecp_utest3\n";
+
+    int n = 8;
+    int size = 32;
+    int n1 = 4;
+    int n2 = 10;
+
+    Vecp<T> *vec = gen_vecp_rand_data(n, size);
+    Vecp<T> vec1(vec, n1);
+    Vecp<T> vec2(vec, n2);
+
+    Vecp<T> *_vec1 = vec->slice(0, n1);
+    Vecp<T> *_vec2 = new VVecp<T>(vec, n2);
+
+    assert(vec1.eq(_vec1));
+    assert(vec2.eq(_vec2));
+
+    delete vec;
+
+    Vecp<T> vec3(&vec2, n1);
+    assert(vec3.eq(&vec1));
+
+    delete _vec1;
+    delete _vec2;
   }
 
   void vecp_utest()
@@ -125,6 +152,7 @@ class VECPUtest
 
     vecp_utest1();
     vecp_utest2();
+    vecp_utest3();
   }
 };
 

--- a/test/vecp_utest.cpp
+++ b/test/vecp_utest.cpp
@@ -5,22 +5,25 @@ template<typename T>
 class VECPUtest
 {
  private:
-   GFP<T> *gfp;
+  GFP<T> *gfp;
+  T max_val;
 
  public:
   VECPUtest() {
     this->gfp = new GFP<T>(65537);
+    this->max_val = 65537;
   }
   ~VECPUtest() {
     delete this->gfp;
   }
 
-  Vecp<T>* gen_vecp_rand_data(int n, int size) {
+  Vecp<T>* gen_vecp_rand_data(int n, int size, int _max = 0) {
+    int max = (_max == 0) ? max_val : _max;
     Vecp<T> *vec = new Vecp<T>(n, size);
     for (int i = 0; i < n; i++) {
       T *buf = new T[size];
       for (int j = 0; j < size; j++) {
-        buf[j] = this->gfp->weak_rand();
+        buf[j] = rand() % max;
       }
       vec->set(i, buf);
     }
@@ -146,6 +149,79 @@ class VECPUtest
     delete _vec2;
   }
 
+  void vecp_utest4()
+  {
+    std::cout << "vecp_utest4\n";
+    int i;
+    int word_size;
+
+    for (i = 0; i <= _log2<T>(sizeof(T)); i++) {
+      word_size = _exp2<T>(i);
+      pack_unpack(word_size);
+    }
+  }
+
+  void pack_unpack(int word_size)
+  {
+    std::cout << "pack_unpack with word_size=" << word_size << "\n";
+    int n = 8;
+    int size = 32;
+    int bytes_size = size * word_size;
+    int i, j, t, u;
+
+    T symb;
+    T max = ((T)1 << word_size) + 1;
+
+    Vecp<T> *words = gen_vecp_rand_data(n, size, max);
+    std::vector<T*> *mem_T = words->get_mem();
+    // std::cout << "words:"; words->dump();
+
+    // pack manually from T to uint8_t
+    Vecp<uint8_t> vec_char(n, bytes_size);
+    std::vector<uint8_t*> *mem_char = vec_char.get_mem();
+    for (i = 0; i < n; i++) {
+      t = 0;
+      T *buf_T = mem_T->at(i);
+      uint8_t *buf_char = mem_char->at(i);
+      for (j = 0; j < size; j++) {
+        symb = buf_T[j];
+        buf_char[t] = (uint8_t)(symb & 0xFF);
+        t++;
+        for (u = 1; u < word_size; u++) {
+          symb >>= 8;
+          buf_char[t] = (uint8_t)(symb & 0xFF);
+          t++;
+        }
+      }
+    }
+
+    /*
+     * pack bufs of type uint8_t to bufs of type T
+     */
+    // tmp vectors to store results
+    Vecp<T> vec_T_tmp(n, size);
+    std::vector<T*> *mem_T_tmp = vec_T_tmp.get_mem();
+    pack<uint8_t, T>(mem_char, mem_T_tmp, n, size, word_size);
+    // std::cout << "vec_char:"; vec_char.dump();
+    // std::cout << "vec_T_tmp:"; vec_T_tmp.dump();
+    // check
+    assert(vec_T_tmp.eq(words));
+
+    /*
+     * unpack bufs of type T to bufs of type uint8_t
+     */
+    // tmp vectors to store results
+    Vecp<uint8_t> vec_char_tmp(n, bytes_size);
+    std::vector<uint8_t*> *mem_char_tmp = vec_char_tmp.get_mem();
+    unpack<T, uint8_t>(mem_T_tmp, mem_char_tmp, n, size, word_size);
+    // std::cout << "vec_T_tmp:"; vec_T_tmp.dump();
+    // std::cout << "vec_char_tmp:"; vec_char_tmp.dump();
+    // check
+    assert(vec_char_tmp.eq(&vec_char));
+
+    delete words;
+  }
+
   void vecp_utest()
   {
     std::cout << "vecp_utest with sizeof(T)=" << sizeof(T) << "\n";
@@ -153,6 +229,7 @@ class VECPUtest
     vecp_utest1();
     vecp_utest2();
     vecp_utest3();
+    vecp_utest4();
   }
 };
 


### PR DESCRIPTION
# Vecp: wrapper vector of pointers

Wrapper of a vector of `n` buffers each of `size` elements of type T
  std::vector<T*> vec(n) where vec[i] = T[size];

# VVecp: virtual Vecp vector

Virtual vector that returns zero chunk beyond managed vector length

# FEC: encoding on packet of pack

A data packet is composed of 'k' data buffers each of a given size.
Output packet is composed of 'n' coded buffers each of the same size.
Encoding is performed in data packets to generate 'n' output packets.

Since data is read as char buffers, and FEC works on type T where each
number uses 'word_size' to store useful data, we need to pack and unpack
packets.

1. Pack
a. Input
- A vector of buffers of type Ts
- Word_size: number of bytes per output elements to store data
b. Output
Vector of buffers of type Td
c. Condition
- sizeof(Td) >= Word_size
- Word_size % sizeof(Ts) = 0
d. How to do
- Cast buffers of source to a type corresponding to 'Word_size'
- Copy casted elements to buffers of destination

2. UnPack
a. Input
- A vector of buffers of type Ts
- Word_size: number of bytes per input elements to store data
b. Output
Vector of buffers of type Td
c. Condition
- sizeof(Ts) >= Word_size
- Word_size % sizeof(Td) = 0
d. How to do
- Cast buffers of destination to a type corresponding to 'Word_size'
- Copy source elements to casted elements
