### PR TITLE
Fix and minor enhancement

### DIFF
--- a/src/fec.h
+++ b/src/fec.h
@@ -50,6 +50,7 @@ inline void pack_next(std::vector<Ts*> *src, std::vector<Td*> *dest, int n,
     tmp[i] = static_cast<Tw*>(static_cast<void*>(src->at(i)));
     std::copy_n(tmp[i], size, dest->at(i));
   }
+  tmp.shrink_to_fit();
 }
 
 /*
@@ -96,6 +97,7 @@ inline void unpack_next(std::vector<Ts*> *src, std::vector<Td*> *dest, int n,
     tmp[i] = static_cast<Tw*>(static_cast<void*>(dest->at(i)));
     std::copy_n(src->at(i), size, tmp[i]);
   }
+  tmp.shrink_to_fit();
 }
 
 /*

--- a/src/fft2k.h
+++ b/src/fft2k.h
@@ -194,15 +194,15 @@ void FFT2K<T>::_fftp(Vecp<T> *output, Vecp<T> *input, bool inv)
   // separate even and odd elements of input
   input->separate_even_odd(&i_even, &i_odd);
 
-  Vecp<T> *o_even = output->slice(0, half);
-  Vecp<T> *o_odd = output->slice(half, this->n);
+  Vecp<T> o_even(output, 0, half);
+  Vecp<T> o_odd(output, half, this->n);
 
   if (inv) {
-    fftk->fft_inv(o_even, &i_even);
-    fftk->fft_inv(o_odd, &i_odd);
+    fftk->fft_inv(&o_even, &i_even);
+    fftk->fft_inv(&o_odd, &i_odd);
   } else {
-    fftk->fft(o_even, &i_even);
-    fftk->fft(o_odd, &i_odd);
+    fftk->fft(&o_even, &i_even);
+    fftk->fft(&o_odd, &i_odd);
   }
 
   /*
@@ -210,7 +210,7 @@ void FFT2K<T>::_fftp(Vecp<T> *output, Vecp<T> *input, bool inv)
    * output[i] = even[i] - w * odd[i] otherwise
    */
   // tmp vec to store o_odd
-  Vecp<T> _o_odd(o_odd);
+  Vecp<T> _o_odd(&o_odd);
 
   // multiply _o_odd by w or inv_w
   if (inv)
@@ -218,14 +218,11 @@ void FFT2K<T>::_fftp(Vecp<T> *output, Vecp<T> *input, bool inv)
   else
     this->gf->mul_vec_to_vecp(W_half, &_o_odd);
   // set o_odd = o_even to set two halves of output = o_even
-  o_odd->copy(o_even);
+  o_odd.copy(&o_even);
   // add _o_odd to o_even to get: even + w * odd
-  this->gf->add_vecp_to_vecp(&_o_odd, o_even);
+  this->gf->add_vecp_to_vecp(&_o_odd, &o_even);
   // substract o_odd by _o_odd to get: even - w * odd
-  this->gf->sub_vecp_to_vecp(o_odd, &_o_odd, o_odd);
-
-  delete o_even;
-  delete o_odd;
+  this->gf->sub_vecp_to_vecp(&o_odd, &_o_odd, &o_odd);
 }
 
 template <typename T>

--- a/src/vecp.h
+++ b/src/vecp.h
@@ -121,11 +121,8 @@ Vecp<T>::Vecp(Vecp<T>* vec, int begin, int end)
   this->size = vec->get_size();
   this->mem_len = this->n*this->size;
   this->mem_alloc_case = 1;
-
-  typename std::vector<T*>::const_iterator first =
-    vec->get_mem()->begin() + begin;
-  typename std::vector<T*>::const_iterator last = vec->get_mem()->begin() + end;
-  this->mem = new std::vector<T*>(first, last);
+  this->mem = new std::vector<T*>(vec->get_mem()->begin() + begin,
+                                  vec->get_mem()->begin() + end);
 }
 
 template <typename T>
@@ -137,6 +134,7 @@ Vecp<T>::~Vecp()
         delete[] this->mem->at(i);
       }
     }
+    this->mem->shrink_to_fit();
     delete this->mem;
   }
 }
@@ -221,6 +219,7 @@ void Vecp<T>::separate_even_odd()
   for (i = 0; i < n; i++) {
     mem->at(i) = _mem[i];
   }
+  _mem.shrink_to_fit();
 }
 
 template <typename T>

--- a/src/vvecp.h
+++ b/src/vvecp.h
@@ -39,5 +39,6 @@ VVecp<T>::~VVecp()
   if (zero_chunk != nullptr) {
     delete[] zero_chunk;
   }
+  this->mem->shrink_to_fit();
   delete this->mem;
 }

--- a/src/vvecp.h
+++ b/src/vvecp.h
@@ -37,7 +37,7 @@ template <typename T>
 VVecp<T>::~VVecp()
 {
   if (zero_chunk != nullptr) {
-    delete zero_chunk;
+    delete[] zero_chunk;
   }
   delete this->mem;
 }

--- a/test/vecp_utest.cpp
+++ b/test/vecp_utest.cpp
@@ -46,16 +46,16 @@ class VECPUtest
     std::vector<T*> *mem1 = vec1->get_mem();
     // vec1->dump();
 
-    Vecp<T> *vec2 = vec1->slice(begin, end);
-    std::vector<T*> *mem2 = vec2->get_mem();
-    assert(vec2->get_n() == end - begin);
-    assert(vec2->get_size() == vec1->get_size());
+    Vecp<T> vec2(vec1, begin, end);
+    std::vector<T*> *mem2 = vec2.get_mem();
+    assert(vec2.get_n() == end - begin);
+    assert(vec2.get_size() == vec1->get_size());
     for (i = 0; i < end - begin; i++) {
       for (j = 0; j < size; j++) {
         mem2->at(i)[j] = mem1->at(i + begin)[j];
       }
     }
-    // vec2->dump();
+    // vec2.dump();
 
     std::vector<T*> mem3(end - begin, nullptr);
     for (int i = 0; i < end - begin; i++) {
@@ -64,10 +64,9 @@ class VECPUtest
     Vecp<T> vec3(end - begin, size, &mem3);
     // vec3.dump();
 
-    assert(vec2->eq(&vec3));
+    assert(vec2.eq(&vec3));
 
     delete vec1;
-    delete vec2;
   }
 
   void vecp_utest2()
@@ -93,8 +92,10 @@ class VECPUtest
     vec1->separate_even_odd();
     // vec1->dump();
 
-    assert(i_even->eq(vec1->slice(0, half)));
-    assert(i_odd->eq(vec1->slice(half, n)));
+    Vecp<T> _i_even(vec1, 0, half);
+    Vecp<T> _i_odd(vec1, half, n);
+    assert(i_even->eq(&_i_even));
+    assert(i_odd->eq(&_i_odd));
 
     // vec2.dump();
 
@@ -134,10 +135,10 @@ class VECPUtest
     Vecp<T> vec1(vec, n1);
     Vecp<T> vec2(vec, n2);
 
-    Vecp<T> *_vec1 = vec->slice(0, n1);
+    Vecp<T> _vec1(vec, 0, n1);
     Vecp<T> *_vec2 = new VVecp<T>(vec, n2);
 
-    assert(vec1.eq(_vec1));
+    assert(vec1.eq(&_vec1));
     assert(vec2.eq(_vec2));
 
     delete vec;
@@ -145,7 +146,6 @@ class VECPUtest
     Vecp<T> vec3(&vec2, n1);
     assert(vec3.eq(&vec1));
 
-    delete _vec1;
     delete _vec2;
   }
 


### PR DESCRIPTION
###  Vecp: constructed by slicing from another 

Constructor of Vecp by slicing from a given vector. Buffers are sliced from `begin` (inclusive) to `end` (exclusive)

Remove `slice` function from Vecp.

### VVecp: fix destructor VVecp

### Vecp: release mem of vector use shrink_to_fit
