### PR TITLE
Eh/packetize

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -680,6 +680,11 @@ int main(int argc, char **argv)
     }
   }
 
+  // Currently support operating on packet:FNTRS
+  if (params.fec_type != EC_TYPE_FNTRS) {
+      params.operation_on_packet = false;
+  }
+
   if (params.pkt_size <= 0) {
     params.operation_on_packet = false;
   }

--- a/src/fecfntrs.h
+++ b/src/fecfntrs.h
@@ -64,9 +64,11 @@ class FECFNTRS : public FEC<T>
   {
     VVec<T> vwords(words, n);
     fft->fft(output, &vwords);
+    // max_value = 2^x
+    T thres = fft->get_gf()->card() - 1;
     // check for out of range value in output
     for (int i = 0; i < this->code_len; i++) {
-      if (output->get(i) == (fft->get_gf()->card() - 1)) {
+      if (output->get(i) & thres) {
         char buf[256];
         snprintf(buf, sizeof (buf), "%zd:%d", offset, i);
         assert(nullptr != props[i]);
@@ -87,7 +89,7 @@ class FECFNTRS : public FEC<T>
     for (int i = 0; i < this->code_len; i++) {
       T *chunk = output->get(i);
       for (int j = 0; j < size; j++) {
-        if (chunk[j] == thres) {
+        if (chunk[j] & thres) {
           char buf[256];
           snprintf(buf, sizeof (buf), "%zd:%d", offset + j*this->word_size, i);
           assert(nullptr != props[i]);

--- a/src/fft2.h
+++ b/src/fft2.h
@@ -83,5 +83,5 @@ void FFT2<T>::ifft(Vecp<T> *output, Vecp<T> *input)
 {
   fft_inv(output, input);
   if (this->inv_n_mod_p > 1)
-    this->gf->mul_vec_to_vecp(this->vec_inv_n, output);
+    this->gf->mul_vec_to_vecp(this->vec_inv_n, output, output);
 }

--- a/src/fft2k.h
+++ b/src/fft2k.h
@@ -27,9 +27,7 @@ class FFT2K : public DFT<T>
   T w;
   T inv_w;
   Vec<T> *W = nullptr;
-  Vec<T> *W_half = nullptr;
   Vec<T> *inv_W = nullptr;
-  Vec<T> *inv_W_half = nullptr;
 
   FFT2<T> *fft2 = nullptr;
   FFT2K<T> *fftk = nullptr;
@@ -81,13 +79,6 @@ FFT2K<T>::FFT2K(GF<T> *gf, int n, int N) : DFT<T>(gf, n)
     gf->compute_omegas(W, n, w);
     gf->compute_omegas(inv_W, n, inv_w);
 
-    W_half = new Vec<T>(gf, k);
-    inv_W_half = new Vec<T>(gf, k);
-    for (int i = 0; i < k; i++) {
-      W_half->set(i, W->get(i));
-      inv_W_half->set(i, inv_W->get(i));
-    }
-
     this->fftk = new FFT2K<T>(gf, k, this->N);
 
     this->even = new Vec<T>(this->gf, k);
@@ -111,8 +102,6 @@ FFT2K<T>::~FFT2K()
     if (fftk != nullptr) delete fftk;
     if (W != nullptr) delete W;
     if (inv_W != nullptr) delete inv_W;
-    if (W_half != nullptr) delete W_half;
-    if (inv_W_half != nullptr) delete inv_W_half;
     if (even != nullptr) delete even;
     if (_even != nullptr) delete _even;
     if (odd != nullptr) delete odd;
@@ -206,23 +195,19 @@ void FFT2K<T>::_fftp(Vecp<T> *output, Vecp<T> *input, bool inv)
   }
 
   /*
-   * output[i] = even[i] + w * odd[i] for 0 <= i < n/2
-   * output[i] = even[i] - w * odd[i] otherwise
+   * output[i] = even[i] + w * odd[i]
    */
-  // tmp vec to store o_odd
-  Vecp<T> _o_odd(&o_odd);
-
-  // multiply _o_odd by w or inv_w
+  // store input as w * odd[i]
+  V2Vecp<T> v2_o_odd(&o_odd);
   if (inv)
-    this->gf->mul_vec_to_vecp(inv_W_half, &_o_odd);
+    this->gf->mul_vec_to_vecp(inv_W, &v2_o_odd, input);
   else
-    this->gf->mul_vec_to_vecp(W_half, &_o_odd);
+    this->gf->mul_vec_to_vecp(W, &v2_o_odd, input);
+
   // set o_odd = o_even to set two halves of output = o_even
   o_odd.copy(&o_even);
-  // add _o_odd to o_even to get: even + w * odd
-  this->gf->add_vecp_to_vecp(&_o_odd, &o_even);
-  // substract o_odd by _o_odd to get: even - w * odd
-  this->gf->sub_vecp_to_vecp(&o_odd, &_o_odd, &o_odd);
+  // add input to output to get: even + w * odd
+  this->gf->add_vecp_to_vecp(input, output);
 }
 
 template <typename T>

--- a/src/fft2k.h
+++ b/src/fft2k.h
@@ -252,5 +252,5 @@ void FFT2K<T>::ifft(Vecp<T> *output, Vecp<T> *input)
    * We need to divide output to `N` for the inverse formular
    */
   if ((this->k == this->N / 2) && (this->inv_n_mod_p > 1))
-      this->gf->mul_vec_to_vecp(this->vec_inv_n, output);
+      this->gf->mul_vec_to_vecp(this->vec_inv_n, output, output);
 }

--- a/src/ntl.h
+++ b/src/ntl.h
@@ -58,6 +58,7 @@ typedef enum
 #include "v2vec.h"
 #include "vecp.h"
 #include "vvecp.h"
+#include "v2vecp.h"
 #include "vcvec.h"
 #include "vmvec.h"
 #include "mat.h"

--- a/src/rn.h
+++ b/src/rn.h
@@ -38,7 +38,7 @@ public:
   T exp_quick(T base, T exponent);
   T log_naive(T base, T exponent);
   virtual void mul_coef_to_buf(T a, T* src, T* dest, size_t len);
-  virtual void mul_vec_to_vecp(Vec<T>* u, Vecp<T>* v);
+  virtual void mul_vec_to_vecp(Vec<T>* u, Vecp<T>* src, Vecp<T>* dest);
   virtual void add_two_bufs(T* src, T* dest, size_t len);
   virtual void add_vecp_to_vecp(Vecp<T>* src, Vecp<T>* dest);
   virtual void sub_two_bufs(T* bufa, T* bufb, T* res, size_t len);
@@ -296,13 +296,13 @@ void RN<T>::mul_coef_to_buf(T a, T* src, T* dest, size_t len) {
 }
 
 template <typename T>
-void RN<T>::mul_vec_to_vecp(Vec<T>* u, Vecp<T>* v) {
-  assert(u->get_n() == v->get_n());
+void RN<T>::mul_vec_to_vecp(Vec<T>* u, Vecp<T>* src, Vecp<T>* dest) {
+  assert(u->get_n() == src->get_n());
   int i;
   int n = u->get_n();
-  size_t len = v->get_size();
+  size_t len = src->get_size();
   for (i = 0; i < n; i++) {
-    this->mul_coef_to_buf(u->get(i), v->get(i), v->get(i), len);
+    this->mul_coef_to_buf(u->get(i), src->get(i), dest->get(i), len);
   }
 }
 

--- a/src/v2vecp.h
+++ b/src/v2vecp.h
@@ -1,0 +1,44 @@
+/* -*- mode: c++ -*- */
+#pragma once
+
+/**
+ * Virtual (v->get_n()*2) x 1 vertical vector for the need of
+ * Cooley-Tukey algorithm
+ *
+ * | v_0 |
+ * | v_1 |
+ * | ...
+ * | v_b |
+ * | v_0 |
+ * | v_1 |
+ * | ...
+ * | v_b |
+ */
+template<typename T>
+class V2Vecp : public Vecp<T>
+{
+ private:
+  Vecp<T> *vec;
+ public:
+  explicit V2Vecp(Vecp<T> *vec);
+  T* get(int i);
+};
+
+template <typename T>
+V2Vecp<T>::V2Vecp(Vecp<T> *vec) :
+  Vecp<T>(2*vec->get_n(), vec->get_size(), vec->get_mem())
+{
+  this->vec = vec;
+}
+
+template <typename T>
+T* V2Vecp<T>::get(int i)
+{
+  int vec_n = vec->get_n();
+  assert(i >= 0 && i < 2*vec_n);
+
+  if (i < vec_n)
+    return vec->get(i);
+  else
+    return vec->get(i - vec_n);
+}


### PR DESCRIPTION
Enhance perf:
- Avoid subtraction that costs more than addition and multiplication
- FFT2k: use input as a temporary buf to calculate output. Do not need to allocate new memory.