### PR TITLE
FFT2k: enhancement for using Vecp

### DIFF
--- a/src/fecfntrs.h
+++ b/src/fecfntrs.h
@@ -37,7 +37,7 @@ class FECFNTRS : public FEC<T>
     // std::cerr << "n=" << n << "\n";
     // std::cerr << "r=" << r << "\n";
 
-    this->fft = new FFT2K<T>(this->gf, n);
+    this->fft = new FFT2K<T>(this->gf, n, pkt_size);
   }
 
   ~FECFNTRS()

--- a/src/fft2.h
+++ b/src/fft2.h
@@ -83,5 +83,5 @@ void FFT2<T>::ifft(Vecp<T> *output, Vecp<T> *input)
 {
   fft_inv(output, input);
   if (this->inv_n_mod_p > 1)
-    this->gf->mul_vec_to_vecp(this->vec_inv_n, output);
+    this->gf->mul_vec_to_vecp(this->vec_inv_n, output, output);
 }

--- a/src/fft2k.h
+++ b/src/fft2k.h
@@ -26,9 +26,10 @@ class FFT2K : public DFT<T>
   int N;
   T w;
   T inv_w;
+  size_t pkt_size;
   Vec<T> *W = nullptr;
-  Vec<T> *W_half = nullptr;
   Vec<T> *inv_W = nullptr;
+  Vec<T> *W_half = nullptr;
   Vec<T> *inv_W_half = nullptr;
 
   FFT2<T> *fft2 = nullptr;
@@ -40,8 +41,10 @@ class FFT2K : public DFT<T>
   Vec<T> *_odd = nullptr;
   V2Vec<T> *veven = nullptr;
   V2Vec<T> *vodd = nullptr;
+
+  Vecp<T> *tmp_buf = nullptr;
  public:
-  FFT2K(GF<T> *gf, int n, int N = 0);
+  FFT2K(GF<T> *gf, int n, size_t pkt_size = 0, int N = 0);
   ~FFT2K();
   void fft(Vec<T> *output, Vec<T> *input);
   void ifft(Vec<T> *output, Vec<T> *input);
@@ -59,15 +62,18 @@ class FFT2K : public DFT<T>
  *
  * @param gf
  * @param n for now must be a power of 2
+ * @param pkt_size size of packet, i.e. number of symbols per chunk will be
+ *  received and processed at a time
  * @param N original length
  *
  * @return
  */
 template <typename T>
-FFT2K<T>::FFT2K(GF<T> *gf, int n, int N) : DFT<T>(gf, n)
+FFT2K<T>::FFT2K(GF<T> *gf, int n, size_t pkt_size, int N) : DFT<T>(gf, n)
 {
   w = gf->get_nth_root(n);
   inv_w = gf->inv(w);
+  this->pkt_size = pkt_size;
   this->N = N;
   if (this->N == 0)
     this->N = n;
@@ -88,7 +94,7 @@ FFT2K<T>::FFT2K(GF<T> *gf, int n, int N) : DFT<T>(gf, n)
       inv_W_half->set(i, inv_W->get(i));
     }
 
-    this->fftk = new FFT2K<T>(gf, k, this->N);
+    this->fftk = new FFT2K<T>(gf, k, pkt_size, this->N);
 
     this->even = new Vec<T>(this->gf, k);
     this->_even = new Vec<T>(this->gf, k);
@@ -96,6 +102,9 @@ FFT2K<T>::FFT2K(GF<T> *gf, int n, int N) : DFT<T>(gf, n)
     this->odd = new Vec<T>(this->gf, k);
     this->_odd = new Vec<T>(this->gf, k);
     this->vodd = new V2Vec<T>(this->_odd);
+
+    if (this->pkt_size > 0)
+      this->tmp_buf = new Vecp<T>(k, pkt_size);
   } else {
     bypass = true;
     this->fft2 = new FFT2<T>(gf);
@@ -119,6 +128,7 @@ FFT2K<T>::~FFT2K()
     if (_odd != nullptr) delete _odd;
     if (veven != nullptr) delete veven;
     if (vodd != nullptr) delete vodd;
+    if (pkt_size > 0 && tmp_buf != nullptr) delete tmp_buf;
   }
 }
 
@@ -209,20 +219,26 @@ void FFT2K<T>::_fftp(Vecp<T> *output, Vecp<T> *input, bool inv)
    * output[i] = even[i] + w * odd[i] for 0 <= i < n/2
    * output[i] = even[i] - w * odd[i] otherwise
    */
-  // tmp vec to store o_odd
-  Vecp<T> _o_odd(&o_odd);
+  // prepare tm_buf
+  Vecp<T> *_o_odd = nullptr;
+  if (this->pkt_size == 0) {
+    _o_odd = new Vecp<T>(half, size);
+    tmp_buf = _o_odd;
+  }
 
-  // multiply _o_odd by w or inv_w
+  // set tmp_buf = w * o_odd
   if (inv)
-    this->gf->mul_vec_to_vecp(inv_W_half, &_o_odd);
+    this->gf->mul_vec_to_vecp(inv_W_half, &o_odd, tmp_buf);
   else
-    this->gf->mul_vec_to_vecp(W_half, &_o_odd);
-  // set o_odd = o_even to set two halves of output = o_even
-  o_odd.copy(&o_even);
-  // add _o_odd to o_even to get: even + w * odd
-  this->gf->add_vecp_to_vecp(&_o_odd, &o_even);
-  // substract o_odd by _o_odd to get: even - w * odd
-  this->gf->sub_vecp_to_vecp(&o_odd, &_o_odd, &o_odd);
+    this->gf->mul_vec_to_vecp(W_half, &o_odd, tmp_buf);
+
+  // substract o_even by tmp_buf and store in o_dd: o_even - w * o_odd
+  this->gf->sub_vecp_to_vecp(&o_even, tmp_buf, &o_odd);
+  // add tmp_buf to o_even to get: o_even + w * o_odd
+  this->gf->add_vecp_to_vecp(tmp_buf, &o_even);
+
+  if (_o_odd != nullptr)
+    delete _o_odd;
 }
 
 template <typename T>

--- a/src/fft2k.h
+++ b/src/fft2k.h
@@ -252,5 +252,5 @@ void FFT2K<T>::ifft(Vecp<T> *output, Vecp<T> *input)
    * We need to divide output to `N` for the inverse formular
    */
   if ((this->k == this->N / 2) && (this->inv_n_mod_p > 1))
-      this->gf->mul_vec_to_vecp(this->vec_inv_n, output);
+      this->gf->mul_vec_to_vecp(this->vec_inv_n, output, output);
 }

--- a/src/ntl.h
+++ b/src/ntl.h
@@ -58,6 +58,7 @@ typedef enum
 #include "v2vec.h"
 #include "vecp.h"
 #include "vvecp.h"
+#include "v2vecp.h"
 #include "vcvec.h"
 #include "vmvec.h"
 #include "mat.h"

--- a/src/rn.h
+++ b/src/rn.h
@@ -38,7 +38,7 @@ public:
   T exp_quick(T base, T exponent);
   T log_naive(T base, T exponent);
   virtual void mul_coef_to_buf(T a, T* src, T* dest, size_t len);
-  virtual void mul_vec_to_vecp(Vec<T>* u, Vecp<T>* v);
+  virtual void mul_vec_to_vecp(Vec<T>* u, Vecp<T>* src, Vecp<T>* dest);
   virtual void add_two_bufs(T* src, T* dest, size_t len);
   virtual void add_vecp_to_vecp(Vecp<T>* src, Vecp<T>* dest);
   virtual void sub_two_bufs(T* bufa, T* bufb, T* res, size_t len);
@@ -296,13 +296,13 @@ void RN<T>::mul_coef_to_buf(T a, T* src, T* dest, size_t len) {
 }
 
 template <typename T>
-void RN<T>::mul_vec_to_vecp(Vec<T>* u, Vecp<T>* v) {
-  assert(u->get_n() == v->get_n());
+void RN<T>::mul_vec_to_vecp(Vec<T>* u, Vecp<T>* src, Vecp<T>* dest) {
+  assert(u->get_n() == src->get_n());
   int i;
   int n = u->get_n();
-  size_t len = v->get_size();
+  size_t len = src->get_size();
   for (i = 0; i < n; i++) {
-    this->mul_coef_to_buf(u->get(i), v->get(i), v->get(i), len);
+    this->mul_coef_to_buf(u->get(i), src->get(i), dest->get(i), len);
   }
 }
 

--- a/src/v2vecp.h
+++ b/src/v2vecp.h
@@ -1,0 +1,44 @@
+/* -*- mode: c++ -*- */
+#pragma once
+
+/**
+ * Virtual (v->get_n()*2) x 1 vertical vector for the need of
+ * Cooley-Tukey algorithm
+ *
+ * | v_0 |
+ * | v_1 |
+ * | ...
+ * | v_b |
+ * | v_0 |
+ * | v_1 |
+ * | ...
+ * | v_b |
+ */
+template<typename T>
+class V2Vecp : public Vecp<T>
+{
+ private:
+  Vecp<T> *vec;
+ public:
+  explicit V2Vecp(Vecp<T> *vec);
+  T* get(int i);
+};
+
+template <typename T>
+V2Vecp<T>::V2Vecp(Vecp<T> *vec) :
+  Vecp<T>(2*vec->get_n(), vec->get_size(), vec->get_mem())
+{
+  this->vec = vec;
+}
+
+template <typename T>
+T* V2Vecp<T>::get(int i)
+{
+  int vec_n = vec->get_n();
+  assert(i >= 0 && i < 2*vec_n);
+
+  if (i < vec_n)
+    return vec->get(i);
+  else
+    return vec->get(i - vec_n);
+}


### PR DESCRIPTION
When packet size is given, a temporary Vecp is allocated once and used for FFT and iFFT. Otherwise, a new Vecp is created for each operation.

Simplify processing after FFT/iFFT. Each this post-processing requires
- One multiplication of a Vec and a Vecp
- One substraction of two Vecps
- One addition of two Vecps

Concretely, the algo is below:
- o_even and o_odd are "sliced" even and odd parts of output
- tmp_buf (temporary Vecp) is set = W_half * o_odd or inv_W_half * o_odd
  where W_half, inv_W_half is of half size compare to W and inv_W
- update o_odd = o_even - tmp_buf
- update o_even = o_even + tmp_buf